### PR TITLE
Release separate bundles for Blazor and .NET core

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -42,8 +42,14 @@ jobs:
         working-directory: src
         run: powershell .\PackageRelease.ps1 -version LATEST.alpha
 
-      - name: Upload
+      - name: Upload AasxBlazor
         uses: actions/upload-artifact@v2
         with:
-          name: aasx-server.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/aasx-server.zip
+          name: AasxBlazor.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxBlazor.zip
+
+      - name: Upload AasxServerCore
+        uses: actions/upload-artifact@v2
+        with:
+          name: AasxServerCore.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerCore.zip

--- a/src/BuildForRelease.ps1
+++ b/src/BuildForRelease.ps1
@@ -19,20 +19,34 @@ function Main
 {
     Set-Location $PSScriptRoot
 
-    $buildDir = Join-Path $( GetArtefactsDir ) "build" `
-        | Join-Path -ChildPath "Release" `
-        | Join-Path -ChildPath "aasx-server"
+    $baseBuildDir = Join-Path $( GetArtefactsDir ) "build" `
+        | Join-Path -ChildPath "Release"
 
     if ($clean)
     {
-        Write-Host "Removing the build directory: $buildDir"
-        Remove-Item -LiteralPath $buildDir -Force -Recurse
+        Write-Host "Removing the build directory: $baseBuildDir"
+        Remove-Item -LiteralPath $baseBuildDir -Force -Recurse
     }
     else
     {
         AssertDotnet
-        Write-Host "Publishing the solution to: $buildDir"
-        dotnet.exe publish -c Release -o $buildDir
+
+        $targets = $(
+        "AasxBlazor"
+        "AasxServerCore"
+        <#
+        TODO (mristin, 2020-09-01): AasxServerWindows does not compile due to
+        an error related to missing dependencies.
+        #>
+        #"AasxServerWindows"
+        )
+
+        foreach ($target in $targets)
+        {
+            $buildDir = Join-Path $baseBuildDir $target
+            Write-Host "Publishing $target to: $buildDir"
+            dotnet.exe publish -c Release -o $buildDir $target
+        }
     }
 }
 


### PR DESCRIPTION
Previously, we published everything to a single directory and released
all the executables together. With this change, different targets are
separately built (`AasxBlazor` and `AasxServerCore`, respectively) and
separately packaged for release.

The target `AasxServerWindows` could not be built due to an error
related to dependnencies and is still pending.