### PR TITLE
Build AasxServerWindows

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -53,3 +53,9 @@ jobs:
         with:
           name: AasxServerCore.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
           path: artefacts/release/LATEST.alpha/AasxServerCore.zip
+
+      - name: Upload AasxServerWindows
+        uses: actions/upload-artifact@v2
+        with:
+          name: AasxServerWindows.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerWindows.zip

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,1 @@
+packages/

--- a/src/BuildForRelease.ps1
+++ b/src/BuildForRelease.ps1
@@ -15,6 +15,65 @@ Import-Module (Join-Path $PSScriptRoot Common.psm1) -Function `
     AssertDotnet, `
     GetArtefactsDir
 
+<#
+.SYNOPSIS
+Search for MSBuild in the path and at expected locations using `vswhere.exe`.
+#>
+function FindMSBuild
+{
+    $msbuild = $null
+
+    $msbuildCommand = Get-Command "MSBuild.exe" -ErrorAction SilentlyContinue
+    $msbuildFailedSearches = @()
+    if ($null -ne $msbuildCommand)
+    {
+        $msbuild = $msbuildCommand.Source
+    }
+    else
+    {
+        $vswherePath = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (!(Test-Path $vswherePath))
+        {
+            throw "Could not find vswhere at: $vswherePath"
+        }
+
+        $ids = 'Community', 'Professional', 'Enterprise', 'BuildTools' `
+            | ForEach-Object { 'Microsoft.VisualStudio.Product.' + $_ }
+
+        $instance = & $vswherePath -latest -products $ids -requires Microsoft.Component.MSBuild -format json `
+            | Convertfrom-Json `
+            | Select-Object -first 1
+
+        $msbuildPath = Join-Path $instance.installationPath 'MSBuild\15.0\Bin\MSBuild.exe'
+        if (Test-Path $msbuildPath)
+        {
+            $msbuild = $msbuildPath
+        }
+        else
+        {
+            $msbuildFailedSearches += $msbuildPath
+
+            $msbuildPath = Join-Path $instance.installationPath 'MSBuild\Current\Bin\MSBuild.exe'
+            if (Test-Path $msbuildPath)
+            {
+                $msbuild = $msbuildPath
+            }
+            else
+            {
+                $msbuildFailedSearches += $msbuildPath
+            }
+        }
+    }
+
+    if (!$msbuild)
+    {
+        throw "Could not find MSBuild in PATH and at these locations: $( $msbuildFailedSearches -join ';' )"
+    }
+
+    return $msbuild
+}
+
+
 function Main
 {
     Set-Location $PSScriptRoot
@@ -24,6 +83,13 @@ function Main
 
     if ($clean)
     {
+        Write-Host "dotnet clean'ing ..."
+        dotnet.exe clean
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Failed to dotnet clean."
+        }
+
         Write-Host "Removing the build directory: $baseBuildDir"
         Remove-Item -LiteralPath $baseBuildDir -Force -Recurse
     }
@@ -31,21 +97,59 @@ function Main
     {
         AssertDotnet
 
-        $targets = $(
+        ##
+        # Build dotnet targets
+        ##
+
+        $dotnetTargets = $(
         "AasxBlazor"
         "AasxServerCore"
-        <#
-        TODO (mristin, 2020-09-01): AasxServerWindows does not compile due to
-        an error related to missing dependencies.
-        #>
-        #"AasxServerWindows"
         )
 
-        foreach ($target in $targets)
+        foreach ($target in $dotnetTargets)
         {
             $buildDir = Join-Path $baseBuildDir $target
-            Write-Host "Publishing $target to: $buildDir"
+            Write-Host "Publishing with dotnet $target to: $buildDir"
             dotnet.exe publish -c Release -o $buildDir $target
+
+            if ($LASTEXITCODE -ne 0)
+            {
+                throw "Failed to dotnet publish $target."
+            }
+        }
+
+        ##
+        # Build AasxServerWindows with MSBuild
+        #
+        # This is necessary as AasxServerWindows depends on
+        # .NET Framework 4.7.2.
+        ##
+
+        if ($null -eq (Get-Command "nuget.exe" -ErrorAction SilentlyContinue))
+        {
+           throw "Unable to find nuget.exe in your PATH"
+        }
+
+        $msbuild = FindMSBuild
+
+        $target = "AasxServerWindows"
+
+        Write-Host "Restoring NuGet dependencies for $target ..."
+        nuget.exe restore $target -PackagesDirectory packages
+
+        $buildDir = Join-Path $baseBuildDir $target
+        Write-Host "Building with MSBuild $target to: $buildDir"
+        & $msbuild `
+            "/p:OutputPath=$buildDir" `
+            "/p:Configuration=Release" `
+            "/p:Platform=x64" `
+            /maxcpucount `
+            $target `
+            /t:build
+
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Failed to MSBuild $target."
         }
     }
 }

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -22,11 +22,7 @@ function PackageRelease($outputDir)
     $targets = $(
     "AasxBlazor"
     "AasxServerCore"
-    <#
-    TODO (mristin, 2020-09-01): AasxServerWindows does not compile due to
-    an error related to missing dependencies.
-    #>
-    #"AasxServerWindows"
+    "AasxServerWindows"
     )
 
     foreach ($target in $targets)


### PR DESCRIPTION
AasxServerWindows depends on .NET Framework, so it can not be built with
dotnet command. Hence, we build it with MSBuild in a separate step of
the build script.