### PR TITLE
Build for both Windows and Linux

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -42,20 +42,32 @@ jobs:
         working-directory: src
         run: powershell .\PackageRelease.ps1 -version LATEST.alpha
 
-      - name: Upload AasxServerBlazor
+      - name: Upload AasxServerBlazor.win-x64
         uses: actions/upload-artifact@v2
         with:
-          name: AasxServerBlazor.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxServerBlazor.zip
+          name: AasxServerBlazor.win-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerBlazor.win-x64.zip
 
-      - name: Upload AasxServerCore
+      - name: Upload AasxServerBlazor.linux-x64
         uses: actions/upload-artifact@v2
         with:
-          name: AasxServerCore.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxServerCore.zip
+          name: AasxServerBlazor.linux-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerBlazor.linux-x64.zip
 
-      - name: Upload AasxServerWindows
+      - name: Upload AasxServerCore.win-x64
         uses: actions/upload-artifact@v2
         with:
-          name: AasxServerWindows.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxServerWindows.zip
+          name: AasxServerCore.win-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerCore.win-x64.zip
+
+      - name: Upload AasxServerCore.linux-x64
+        uses: actions/upload-artifact@v2
+        with:
+          name: AasxServerCore.linux-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerCore.linux-x64.zip
+
+      - name: Upload AasxServerWindows.win-x64
+        uses: actions/upload-artifact@v2
+        with:
+          name: AasxServerWindows.win-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerWindows.win-x64.zip

--- a/src/BuildForRelease.ps1
+++ b/src/BuildForRelease.ps1
@@ -106,15 +106,26 @@ function Main
         "AasxServerCore"
         )
 
+        $runtimes = @(
+        "win-x64"
+        "linux-x64"
+        )
+
         foreach ($target in $dotnetTargets)
         {
-            $buildDir = Join-Path $baseBuildDir $target
-            Write-Host "Publishing with dotnet $target to: $buildDir"
-            dotnet.exe publish -c Release -o $buildDir $target
-
-            if ($LASTEXITCODE -ne 0)
+            foreach ($runtime in $runtimes)
             {
-                throw "Failed to dotnet publish $target."
+                $buildDir = Join-Path $baseBuildDir "$target.$runtime"
+
+                Write-Host ("Publishing with dotnet $target " +
+                    "for runtime $runtime to: $buildDir")
+
+                dotnet.exe publish -c Release -o $buildDir -r $runtime $target
+                if ($LASTEXITCODE -ne 0)
+                {
+                    throw ("Failed to dotnet publish $target " +
+                        "for runtime $runtime.")
+                }
             }
         }
 
@@ -137,7 +148,7 @@ function Main
         Write-Host "Restoring NuGet dependencies for $target ..."
         nuget.exe restore $target -PackagesDirectory packages
 
-        $buildDir = Join-Path $baseBuildDir $target
+        $buildDir = Join-Path $baseBuildDir "$target.win-x64"
         Write-Host "Building with MSBuild $target to: $buildDir"
         & $msbuild `
             "/p:OutputPath=$buildDir" `

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -19,15 +19,17 @@ function PackageRelease($outputDir)
     $baseBuildDir = Join-Path $( GetArtefactsDir ) "build" `
         | Join-Path -ChildPath "Release"
 
-    $targets = $(
-    "AasxServerBlazor"
-    "AasxServerCore"
-    "AasxServerWindows"
+    $targetsRuntimes = $(
+    "AasxServerBlazor.win-x64"
+    "AasxServerBlazor.linux-x64"
+    "AasxServerCore.win-x64"
+    "AasxServerCore.linux-x64"
+    "AasxServerWindows.win-x64"
     )
 
-    foreach ($target in $targets)
+    foreach ($targetRuntime in $targetsRuntimes)
     {
-        $buildDir = Join-Path $baseBuildDir $target
+        $buildDir = Join-Path $baseBuildDir $targetRuntime
 
         if (!(Test-Path $buildDir))
         {
@@ -36,11 +38,11 @@ function PackageRelease($outputDir)
                     "with BuildForRelease.ps1?")
         }
 
-        $targetOutputDir = Join-Path $outputDir $target
+        $targetOutputDir = Join-Path $outputDir $targetRuntime
 
         New-Item -ItemType Directory -Force -Path $outputDir|Out-Null
 
-        $archPath = Join-Path $outputDir "$target.zip"
+        $archPath = Join-Path $outputDir "$targetRuntime.zip"
 
         Write-Host "Compressing to: $archPath"
 


### PR DESCRIPTION
So far, we built and released only binaries for Windows. With this
change, we also build and release binaries for Linux.

This is also relevant for releasing docker images in one of the next
commits.