### PR TITLE
Release AasxServerBlazor instead of AasxBlazor

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -42,11 +42,11 @@ jobs:
         working-directory: src
         run: powershell .\PackageRelease.ps1 -version LATEST.alpha
 
-      - name: Upload AasxBlazor
+      - name: Upload AasxServerBlazor
         uses: actions/upload-artifact@v2
         with:
-          name: AasxBlazor.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxBlazor.zip
+          name: AasxServerBlazor.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerBlazor.zip
 
       - name: Upload AasxServerCore
         uses: actions/upload-artifact@v2

--- a/src/BuildForRelease.ps1
+++ b/src/BuildForRelease.ps1
@@ -102,7 +102,7 @@ function Main
         ##
 
         $dotnetTargets = $(
-        "AasxBlazor"
+        "AasxServerBlazor"
         "AasxServerCore"
         )
 

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -20,7 +20,7 @@ function PackageRelease($outputDir)
         | Join-Path -ChildPath "Release"
 
     $targets = $(
-    "AasxBlazor"
+    "AasxServerBlazor"
     "AasxServerCore"
     "AasxServerWindows"
     )


### PR DESCRIPTION
The project `AasxBlazor` was renamed to `AasxServerBlazor`. This change
reflects this rename in continuous integration.