### PR TITLE
Fix startForDemo.bat's

### DIFF
--- a/src/AasxServerBlazor/startForDemo.bat
+++ b/src/AasxServerBlazor/startForDemo.bat
@@ -1,1 +1,1 @@
-AasxServerBlazor.exe -host 0.0.0.0 -OPC -REST -datapath aasxs
+AasxServerBlazor.exe -REST -datapath aasxs

--- a/src/AasxServerBlazor/startForDemo.sh
+++ b/src/AasxServerBlazor/startForDemo.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./AasxServerBlazor -host 0.0.0.0 -OPC -REST -datapath ./aasxs
+./AasxServerBlazor -REST -datapath ./aasxs

--- a/src/AasxServerCore/startForDemo.bat
+++ b/src/AasxServerCore/startForDemo.bat
@@ -1,1 +1,1 @@
-AasxServerCore.exe -host 0.0.0.0 -OPC -REST -datapath aasxs
+AasxServerCore.exe -REST -datapath aasxs

--- a/src/AasxServerCore/startForDemo.sh
+++ b/src/AasxServerCore/startForDemo.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./AasxServerCore -host 0.0.0.0 -OPC -REST -datapath ./aasxs
+./AasxServerCore -REST -datapath ./aasxs


### PR DESCRIPTION
Serving OPC is not necessary for the demonstration, so we remove it.
Moreover, Windows does not support serving at host `0.0.0.0`, so that
argument is also removed.