### PR TITLE
Point to `adminshellio/*` docker repositories

### DIFF
--- a/.github/workflows/build-and-publish-docker-images.yml
+++ b/.github/workflows/build-and-publish-docker-images.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: mristin/aasx-server-blazor
+          repository: adminshellio/aasx-server-blazor-for-demo
           tag_with_ref: true
           dockerfile: src/docker/Dockerfile-AasxServerBlazor
 
@@ -24,6 +24,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: mristin/aasx-server-core
+          repository: adminshellio/aasx-server-core-for-demo
           tag_with_ref: true
           dockerfile: src/docker/Dockerfile-AasxServerCore

--- a/README.md
+++ b/README.md
@@ -84,20 +84,20 @@ a workflow which is executed on each push to master branch.
 We provide pre-built docker images meant for demonstration purposes at the 
 following DockerHub repositories:
 
-* `blazor`: https://hub.docker.com/repository/docker/mristin/aasx-server-blazor
-* `core`: https://hub.docker.com/repository/docker/mristin/aasx-server-core
+* `blazor`: https://hub.docker.com/repository/docker/adminshellio/aasx-server-blazor-for-demo
+* `core`: https://hub.docker.com/repository/docker/adminshellio/aasx-server-core-for-demo
 
 For example, to pull the latest `core` variant of the server for the 
 demonstration, invoke:
 
 ```
-docker pull mristin/aasx-server-core
+docker pull adminshellio/aasx-server-core-for-demo
 ```
 
 You can then run the container with:
 
 ```
-docker run -d -p 51210:51210 -p 51310:51310 aasx-server-core
+docker run -d -p 51210:51210 -p 51310:51310 aasx-server-core-for-demo
 ```
 
 ### Build Docker Containers for Demonstration on Linux/MacOS

--- a/src/BuildDockerImages.ps1
+++ b/src/BuildDockerImages.ps1
@@ -20,7 +20,7 @@ function Main
     # AasxServerBlazor
     ##
     
-    $imageTag = "aasx-server-blazor"
+    $imageTag = "aasx-server-blazor-for-demo"
     Write-Host "Building the docker image: $imageTag"
     docker build `
         -t $imageTag `
@@ -33,7 +33,7 @@ function Main
     # AasxServerCore
     ##
     
-    $imageTag = "aasx-server-core"
+    $imageTag = "aasx-server-core-for-demo"
     Write-Host "Building the docker image: $imageTag"
     docker build `
         -t $imageTag `


### PR DESCRIPTION
This patch changes all the pointers to `mristin/*` dockerhub
repositories to `adminshellio/*` repositories.

Additionally, the suffix `-for-demo` is added to the images to allow for
distinction from production or experimental images in the future.