### PR TITLE
Remove runtimes from releases

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -42,32 +42,20 @@ jobs:
         working-directory: src
         run: powershell .\PackageRelease.ps1 -version LATEST.alpha
 
-      - name: Upload AasxServerBlazor.win-x64
+      - name: Upload AasxServerBlazor
         uses: actions/upload-artifact@v2
         with:
-          name: AasxServerBlazor.win-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxServerBlazor.win-x64.zip
+          name: AasxServerBlazor.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerBlazor.zip
 
-      - name: Upload AasxServerBlazor.linux-x64
+      - name: Upload AasxServerCore
         uses: actions/upload-artifact@v2
         with:
-          name: AasxServerBlazor.linux-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxServerBlazor.linux-x64.zip
+          name: AasxServerCore.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerCore.zip
 
-      - name: Upload AasxServerCore.win-x64
+      - name: Upload AasxServerWindows
         uses: actions/upload-artifact@v2
         with:
-          name: AasxServerCore.win-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxServerCore.win-x64.zip
-
-      - name: Upload AasxServerCore.linux-x64
-        uses: actions/upload-artifact@v2
-        with:
-          name: AasxServerCore.linux-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxServerCore.linux-x64.zip
-
-      - name: Upload AasxServerWindows.win-x64
-        uses: actions/upload-artifact@v2
-        with:
-          name: AasxServerWindows.win-x64.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
-          path: artefacts/release/LATEST.alpha/AasxServerWindows.win-x64.zip
+          name: AasxServerWindows.LATEST.alpha.${{ steps.setTimestamp.outputs.timestamp }}
+          path: artefacts/release/LATEST.alpha/AasxServerWindows.zip

--- a/README.md
+++ b/README.md
@@ -28,29 +28,16 @@ The binaries are available in the [Releases section](
 https://github.com/admin-shell-io/aasx-server/releases
 ). We provide x64 binaries for Windows and Linux.
 
-### Installation & Running
+### Installation
 
-AASX Server depends on .NET Core runtime (`blazor` and `core` variants) 
+AASX Server depends on .NET Core 3.1 runtime (`blazor` and `core` variants) 
 and .NET Framework (`windows` variant), respectively. You need to install the 
 respective runtimes before you start the server.
 
 To deploy the binaries, simply extract the release bundle (*e.g.*, 
-`AasxServerCore.win-x64.zip`) somewhere on your system. 
+`AasxServerCore.zip`) somewhere on your system. 
 
-Invoke the executable with the same name as the variant to start the server.
-
-For example, assuming you run on Linux, call `AasxServerCore` from where you 
-unpacked the release bundle: 
-
-```
-AasxServerCore
-```
-
-To obtain help on individual flags and options, supply the argument `--help`:
-
-```
-./AasxServerCore --help
-```
+### Running for Demonstration
 
 We include an example AASX and various extra files (*e.g.*, certificates) in
 the release bundle so that you can readily start the server for demonstration
@@ -63,6 +50,33 @@ the release bundle and invoke:
 ```
 ./startForDemo.sh
 ``` 
+
+### Running on Windows
+
+Change to the directory where you extracted the release bundle.
+
+Invoke the executable with the same name as the server variant. For example:
+
+```
+AasxServerCore.exe -OPC -REST -datapath /path/to/aasxs
+```
+
+To obtain help on individual flags and options, supply the argument `--help`:
+
+```
+AasxServerCore.exe --help
+```
+
+### Running on Linux
+
+Change to the directory where you extracted the release bundle.
+
+Use `dotnet` to execute the DLL with the same name as the server variant.
+For example:
+
+```
+dotnet AasxServerCore.dll -OPC -REST -datapath /path/to/aasxs
+```
 
 ### Build and Package Binaries
 

--- a/src/AasxServerBlazor/startForDemo.sh
+++ b/src/AasxServerBlazor/startForDemo.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./AasxServerBlazor -REST -datapath ./aasxs
+dotnet AasxServerBlazor.dll -REST -datapath ./aasxs

--- a/src/AasxServerCore/startForDemo.sh
+++ b/src/AasxServerCore/startForDemo.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./AasxServerCore -REST -datapath ./aasxs
+dotnet AasxServerCore.dll -REST -datapath ./aasxs

--- a/src/BuildForRelease.ps1
+++ b/src/BuildForRelease.ps1
@@ -106,26 +106,16 @@ function Main
         "AasxServerCore"
         )
 
-        $runtimes = @(
-        "win-x64"
-        "linux-x64"
-        )
-
         foreach ($target in $dotnetTargets)
         {
-            foreach ($runtime in $runtimes)
+            $buildDir = Join-Path $baseBuildDir $target
+
+            Write-Host "Publishing with dotnet $target to: $buildDir"
+
+            dotnet publish -c Release -o $buildDir $target
+            if ($LASTEXITCODE -ne 0)
             {
-                $buildDir = Join-Path $baseBuildDir "$target.$runtime"
-
-                Write-Host ("Publishing with dotnet $target " +
-                    "for runtime $runtime to: $buildDir")
-
-                dotnet publish -c Release -o $buildDir -r $runtime $target
-                if ($LASTEXITCODE -ne 0)
-                {
-                    throw ("Failed to dotnet publish $target " +
-                        "for runtime $runtime.")
-                }
+                throw "Failed to dotnet publish: $target"
             }
         }
 
@@ -148,7 +138,7 @@ function Main
         Write-Host "Restoring NuGet dependencies for $target ..."
         nuget.exe restore $target -PackagesDirectory packages
 
-        $buildDir = Join-Path $baseBuildDir "$target.win-x64"
+        $buildDir = Join-Path $baseBuildDir $target
         Write-Host "Building with MSBuild $target to: $buildDir"
         & $msbuild `
             "/p:OutputPath=$buildDir" `

--- a/src/PackageRelease.ps1
+++ b/src/PackageRelease.ps1
@@ -19,17 +19,17 @@ function PackageRelease($outputDir)
     $baseBuildDir = Join-Path $( GetArtefactsDir ) "build" `
         | Join-Path -ChildPath "Release"
 
-    $targetsRuntimes = $(
-    "AasxServerBlazor.win-x64"
-    "AasxServerBlazor.linux-x64"
-    "AasxServerCore.win-x64"
-    "AasxServerCore.linux-x64"
-    "AasxServerWindows.win-x64"
+    $targets = $(
+    "AasxServerBlazor"
+    "AasxServerCore"
+    "AasxServerWindows"
     )
 
-    foreach ($targetRuntime in $targetsRuntimes)
+    New-Item -ItemType Directory -Force -Path $outputDir|Out-Null
+
+    foreach ($target in $targets)
     {
-        $buildDir = Join-Path $baseBuildDir $targetRuntime
+        $buildDir = Join-Path $baseBuildDir $target
 
         if (!(Test-Path $buildDir))
         {
@@ -38,11 +38,7 @@ function PackageRelease($outputDir)
                     "with BuildForRelease.ps1?")
         }
 
-        $targetOutputDir = Join-Path $outputDir $targetRuntime
-
-        New-Item -ItemType Directory -Force -Path $outputDir|Out-Null
-
-        $archPath = Join-Path $outputDir "$targetRuntime.zip"
+        $archPath = Join-Path $outputDir "$target.zip"
 
         Write-Host "Compressing to: $archPath"
 


### PR DESCRIPTION
Including the CLR made the binary size bloat. This patch reverts the CI
configuration so that the CLR is excluded from the release. The dotnet
runtime is required on both Windows and Linux to run the releases.