### PR TITLE
Rename `Net46ConsoleServer` to `AasxServer`

### DIFF
--- a/src/AasxServerBlazor/Data/AASService.cs
+++ b/src/AasxServerBlazor/Data/AASService.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AasxServer;
 using AdminShellNS;
-using Net46ConsoleServer;
 using static AasxServerBlazor.Pages.TreePage;
 using static AdminShellNS.AdminShellV20;
 

--- a/src/AasxServerBlazor/Pages/TreePage.razor
+++ b/src/AasxServerBlazor/Pages/TreePage.razor
@@ -119,7 +119,7 @@
 
 
 @inject IJSRuntime js
-@using Net46ConsoleServer;
+@using AasxServer;
 
 @code {
     async Task DownloadFile()

--- a/src/AasxServerBlazor/Program.cs
+++ b/src/AasxServerBlazor/Program.cs
@@ -19,7 +19,7 @@ namespace AasxServerBlazor
 
             CreateHostBuilder(args).Build().RunAsync();
 
-            Net46ConsoleServer.Program.Main(args);
+            AasxServer.Program.Main(args);
 
         }
 

--- a/src/AasxServerCore/Program.cs
+++ b/src/AasxServerCore/Program.cs
@@ -4,8 +4,7 @@
     {
         static void Main(string[] args)
         {
-            Net46ConsoleServer.Program.Main(args);
-
+            AasxServer.Program.Main(args);
         }
     }
 }

--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Permissions;
 using System.Text;
 using System.Text.RegularExpressions;
+using AasxServer;
 using AdminShellNS;
 using Grapevine.Interfaces.Server;
 using Grapevine.Server;
@@ -18,7 +19,6 @@ using Grapevine.Shared;
 using Jose;
 using Jose.jwe;
 using Jose.netstandard1_4;
-using Net46ConsoleServer;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -2650,16 +2650,16 @@ namespace AasxRestServerLibrary
             // get the list
             var aaslist = new List<string>();
 
-            int aascount = Net46ConsoleServer.Program.env.Length;
+            int aascount = AasxServer.Program.env.Length;
 
             for (int i = 0; i < aascount; i++)
             {
-                if (Net46ConsoleServer.Program.env[i] != null)
+                if (AasxServer.Program.env[i] != null)
                 {
                     aaslist.Add(i.ToString() + " : "
-                        + Net46ConsoleServer.Program.env[i].AasEnv.AdministrationShells[0].idShort + " : "
-                        + Net46ConsoleServer.Program.env[i].AasEnv.AdministrationShells[0].identification + " : "
-                        + Net46ConsoleServer.Program.envFileName[i]);
+                        + AasxServer.Program.env[i].AasEnv.AdministrationShells[0].idShort + " : "
+                        + AasxServer.Program.env[i].AasEnv.AdministrationShells[0].identification + " : "
+                        + AasxServer.Program.envFileName[i]);
                 }
             }
 
@@ -2690,9 +2690,9 @@ namespace AasxRestServerLibrary
             }
 
             // return as FILE
-            FileStream packageStream = File.OpenRead(Net46ConsoleServer.Program.envFileName[fileIndex]);
+            FileStream packageStream = File.OpenRead(AasxServer.Program.envFileName[fileIndex]);
 
-            SendStreamResponse(context, packageStream, Path.GetFileName(Net46ConsoleServer.Program.envFileName[fileIndex]));
+            SendStreamResponse(context, packageStream, Path.GetFileName(AasxServer.Program.envFileName[fileIndex]));
             packageStream.Close();
         }
 
@@ -2724,7 +2724,7 @@ namespace AasxRestServerLibrary
             res.confirm = "Authorization = " + accessrights;
 
 
-            Byte[] binaryFile = File.ReadAllBytes(Net46ConsoleServer.Program.envFileName[fileIndex]);
+            Byte[] binaryFile = File.ReadAllBytes(AasxServer.Program.envFileName[fileIndex]);
             string binaryBase64 = Convert.ToBase64String(binaryFile);
 
             string payload = "{ \"file\" : \" " + binaryBase64 + " \" }";
@@ -2732,7 +2732,7 @@ namespace AasxRestServerLibrary
             System.Text.ASCIIEncoding enc = new System.Text.ASCIIEncoding();
             string fileToken = Jose.JWT.Encode(payload, enc.GetBytes(secretString), JwsAlgorithm.HS256);
 
-            res.fileName = Path.GetFileName(Net46ConsoleServer.Program.envFileName[fileIndex]);
+            res.fileName = Path.GetFileName(AasxServer.Program.envFileName[fileIndex]);
             res.fileData = fileToken;
 
             SendJsonResponse(context, res);
@@ -2775,15 +2775,15 @@ namespace AasxRestServerLibrary
         {
             withAuthentification = !Program.noSecurity;
 
-            int aascount = Net46ConsoleServer.Program.env.Length;
+            int aascount = AasxServer.Program.env.Length;
 
             for (int i = 0; i < aascount; i++)
             {
-                if (Net46ConsoleServer.Program.env[i] != null)
+                if (AasxServer.Program.env[i] != null)
                 {
-                    if (Net46ConsoleServer.Program.env[i].AasEnv.AdministrationShells[0].idShort == "Security")
+                    if (AasxServer.Program.env[i].AasEnv.AdministrationShells[0].idShort == "Security")
                     {
-                        foreach (var sm in Net46ConsoleServer.Program.env[i].AasEnv.Submodels)
+                        foreach (var sm in AasxServer.Program.env[i].AasEnv.Submodels)
                         {
                             if (sm != null && sm.idShort != null)
                             {

--- a/src/AasxServerStandardBib/Program.cs
+++ b/src/AasxServerStandardBib/Program.cs
@@ -34,7 +34,7 @@ using Opc.Ua.Configuration;
 using Opc.Ua.Server;
 using Formatting = Newtonsoft.Json.Formatting;
 // using AASXLoader;
-namespace Net46ConsoleServer
+namespace AasxServer
 {
     static public class Program
     {
@@ -767,18 +767,18 @@ namespace Net46ConsoleServer
 
                     adp.source = connectNodeName;
 
-                    int aascount = Net46ConsoleServer.Program.env.Length;
+                    int aascount = Program.env.Length;
 
                     for (int j = 0; j < aascount; j++)
                     {
                         aasListParameters alp = new aasListParameters();
 
-                        if (Net46ConsoleServer.Program.env[j] != null)
+                        if (Program.env[j] != null)
                         {
                             alp.index = j;
-                            alp.idShort = Net46ConsoleServer.Program.env[j].AasEnv.AdministrationShells[0].idShort;
-                            alp.identification = Net46ConsoleServer.Program.env[j].AasEnv.AdministrationShells[0].identification.ToString();
-                            alp.fileName = Net46ConsoleServer.Program.envFileName[j];
+                            alp.idShort = Program.env[j].AasEnv.AdministrationShells[0].idShort;
+                            alp.identification = Program.env[j].AasEnv.AdministrationShells[0].identification.ToString();
+                            alp.fileName = Program.envFileName[j];
 
                             adp.aasList.Add(alp);
                         }
@@ -885,7 +885,7 @@ namespace Net46ConsoleServer
 
                                 dynamic res = new System.Dynamic.ExpandoObject();
 
-                                Byte[] binaryFile = File.ReadAllBytes(Net46ConsoleServer.Program.envFileName[aasIndex]);
+                                Byte[] binaryFile = File.ReadAllBytes(Program.envFileName[aasIndex]);
                                 string binaryBase64 = Convert.ToBase64String(binaryFile);
 
                                 string payload = "{ \"file\" : \" " + binaryBase64 + " \" }";
@@ -893,7 +893,7 @@ namespace Net46ConsoleServer
                                 System.Text.ASCIIEncoding enc = new System.Text.ASCIIEncoding();
                                 string fileToken = Jose.JWT.Encode(payload, enc.GetBytes(AasxRestServerLibrary.AasxHttpContextHelper.secretString), JwsAlgorithm.HS256);
 
-                                res.fileName = Path.GetFileName(Net46ConsoleServer.Program.envFileName[aasIndex]);
+                                res.fileName = Path.GetFileName(Program.envFileName[aasIndex]);
                                 res.fileData = fileToken;
 
                                 string responseJson = JsonConvert.SerializeObject(res, Formatting.Indented);

--- a/src/AasxServerWindows/Program.cs
+++ b/src/AasxServerWindows/Program.cs
@@ -4,7 +4,7 @@
     {
         static void Main(string[] args)
         {
-            Net46ConsoleServer.Program.Main(args);
+            AasxServer.Program.Main(args);
         }
     }
 }


### PR DESCRIPTION
`Net46ConsoleServer` is a misnomer as the reader thinks this is some
kind of a general server. This patch renames it to `AasxServer` in order
to make it evidently more specific.