### PR TITLE
Force overwriting content for demo when building

### DIFF
--- a/src/BuildForRelease.ps1
+++ b/src/BuildForRelease.ps1
@@ -84,7 +84,7 @@ function CopyContentForDemo($Destination)
     Write-Host "Copying content for demo from $contentForDemoDir to: $Destination"
 
     Get-ChildItem -Path $contentForDemoDir `
-        | Copy-Item -Destination $Destination -Recurse -Container
+        | Copy-Item -Destination $Destination -Recurse -Container -Force
 }
 
 function Main


### PR DESCRIPTION
Build script copies recursively the content for demo to the respective
build directories for each target (AasxServerBlazor, AasxServerCore
*etc.*). Previously, the script mistakenly failed when the files already
existed.