### PR TITLE
Fix readme and demo scripts for command-line API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Change to the directory where you extracted the release bundle.
 Invoke the executable with the same name as the server variant. For example:
 
 ```
-AasxServerCore.exe -OPC -REST -datapath /path/to/aasxs
+AasxServerCore.exe --opc --rest -data-path /path/to/aasxs
 ```
 
 To obtain help on individual flags and options, supply the argument `--help`:
@@ -101,7 +101,7 @@ Use `dotnet` to execute the DLL with the same name as the server variant.
 For example:
 
 ```
-dotnet AasxServerCore.dll -OPC -REST -datapath /path/to/aasxs
+dotnet AasxServerCore.dll --opc --rest --data-path /path/to/aasxs
 ```
 
 ### Build and Package Binaries

--- a/src/AasxServerBlazor/startForDemo.bat
+++ b/src/AasxServerBlazor/startForDemo.bat
@@ -1,1 +1,1 @@
-AasxServerBlazor.exe -REST -datapath aasxs
+AasxServerBlazor.exe --rest --data-path aasxs

--- a/src/AasxServerBlazor/startForDemo.sh
+++ b/src/AasxServerBlazor/startForDemo.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-dotnet AasxServerBlazor.dll -REST -datapath ./aasxs
+dotnet AasxServerBlazor.dll --rest --data-path ./aasxs

--- a/src/AasxServerCore/startForDemo.bat
+++ b/src/AasxServerCore/startForDemo.bat
@@ -1,1 +1,1 @@
-AasxServerCore.exe -REST -datapath aasxs
+AasxServerCore.exe --rest --data-path aasxs

--- a/src/AasxServerCore/startForDemo.sh
+++ b/src/AasxServerCore/startForDemo.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-dotnet AasxServerCore.dll -REST -datapath ./aasxs
+dotnet AasxServerCore.dll --rest --data-path ./aasxs


### PR DESCRIPTION
This patch fixes the parts of the Readme and run-for-demo scripts which
were mistakenly omitted in a previous commit.