### PR TITLE
Attach abbreviations to command-line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Usage:
   AasxServerCore [options]
 
 Options:
-  --host <host>                          Host which the server listens on [default: localhost]
-  --port <port>                          Port which the server listens on [default: 51310]
+  -h, --host <host>                      Host which the server listens on [default: localhost]
+  -p, --port <port>                      Port which the server listens on [default: 51310]
   --https                                If set, opens SSL connections. Make sure you bind a certificate to the port before.
   --data-path <data-path>                Path to where the AASXs reside
   --rest                                 If set, starts the REST server

--- a/src/AasxServerStandardBib/Program.cs
+++ b/src/AasxServerStandardBib/Program.cs
@@ -555,12 +555,12 @@ namespace AasxServer
             var rootCommand = new RootCommand("serve AASX packages over different interface")
             {
                 new Option<string>(
-                    new[] {"--host"},
+                    new[] {"--host", "-h"},
                     () => "localhost",
                     "Host which the server listens on"),
 
                 new Option<string>(
-                    new[] {"--port"},
+                    new[] {"--port", "-p"},
                     ()=>"51310",
                     "Port which the server listens on"),
 


### PR DESCRIPTION
This change attaches abbreviation aliases to a subset of command-line
options which are already familiar for the users (such as `-h` for
`--host`).