### PR TITLE
Remove trailing spaces in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AASX Server
 
-AASX Server serves Industrie 4.0 AASX packages accessible by REST, OPC UA and 
+AASX Server serves Industrie 4.0 AASX packages accessible by REST, OPC UA and
 MQTT protocols.
 
 The AASX Server is based on code of AASX Package Explorer (
@@ -16,11 +16,11 @@ There are three variants of the server:
 
 * **windows**. This variant uses .NET Framework 4.7.2. While the .NET Framework
   is outdated, this is the only way how you can start a server on your Windows
-  machine without administrator privileges. 
-  
+  machine without administrator privileges.
+
   Mind that *blazor* and *core* variants require these privileges, so they
   can not be used for demonstration purposes on tightly-administered machines
-  (which are wide-spread in larger organizations and enterprises). 
+  (which are wide-spread in larger organizations and enterprises).
 
 ## Binaries
 
@@ -30,12 +30,12 @@ https://github.com/admin-shell-io/aasx-server/releases
 
 ### Installation
 
-AASX Server depends on .NET Core 3.1 runtime (`blazor` and `core` variants) 
-and .NET Framework (`windows` variant), respectively. You need to install the 
+AASX Server depends on .NET Core 3.1 runtime (`blazor` and `core` variants)
+and .NET Framework (`windows` variant), respectively. You need to install the
 respective runtimes before you start the server.
 
-To deploy the binaries, simply extract the release bundle (*e.g.*, 
-`AasxServerCore.zip`) somewhere on your system. 
+To deploy the binaries, simply extract the release bundle (*e.g.*,
+`AasxServerCore.zip`) somewhere on your system.
 
 ### Running for Demonstration
 
@@ -49,7 +49,7 @@ the release bundle and invoke:
 
 ```
 ./startForDemo.sh
-``` 
+```
 
 ### Running on Windows
 
@@ -106,28 +106,28 @@ dotnet AasxServerCore.dll --opc --rest --data-path /path/to/aasxs
 
 ### Build and Package Binaries
 
-To build the binaries from the source code, run the powershell script 
+To build the binaries from the source code, run the powershell script
 [`src/BuildForRelease.ps1`](src/BuildForRelease.ps1).
 
 To package the binaries for release, call [`src/PackageRelease.ps1`](
 src/PackageRelease.ps1).
 
-For more information on continuous integration, see 
+For more information on continuous integration, see
 [.github/workflows/build-and-package-release.yml](
 .github/workflows/build-and-package-release.yml
-) for a workflow executed on each release and 
+) for a workflow executed on each release and
 [.github/workflows/check-release.yml](.github/workflows/check-release.yml) for
 a workflow which is executed on each push to master branch.
 
 ## Docker Containers for Demonstration
 
-We provide pre-built docker images meant for demonstration purposes at the 
+We provide pre-built docker images meant for demonstration purposes at the
 following DockerHub repositories:
 
 * `blazor`: https://hub.docker.com/repository/docker/adminshellio/aasx-server-blazor-for-demo
 * `core`: https://hub.docker.com/repository/docker/adminshellio/aasx-server-core-for-demo
 
-For example, to pull the latest `core` variant of the server for the 
+For example, to pull the latest `core` variant of the server for the
 demonstration, invoke:
 
 ```
@@ -142,5 +142,5 @@ docker run -d -p 51210:51210 -p 51310:51310 aasx-server-core-for-demo
 
 ### Build Docker Containers for Demonstration on Linux/MacOS
 
-We provide a powershell script to build the docker containers meant for 
-demonstrations at [`src/BuildDockerImages.ps1`](src/BuildDockerImages.ps1). 
+We provide a powershell script to build the docker containers meant for
+demonstrations at [`src/BuildDockerImages.ps1`](src/BuildDockerImages.ps1).


### PR DESCRIPTION
There were a couple of trailing spaces erroneously left in the readme
which makes diff'ing unnecessarily confusing.

The workflow build-and-publish-docker-images was intentionally skipped.
The workflow check-release was intentionally skipped.