### PR TITLE
Fix dockerfiles and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,54 @@ docker pull adminshellio/aasx-server-core-for-demo
 You can then run the container with:
 
 ```
-docker run -d -p 51210:51210 -p 51310:51310 aasx-server-core-for-demo
+docker run \
+    --detach \
+    --network host \
+    adminshellio/aasx-server-core-for-demo
 ```
+
+The server should be accessible now on your localhost. For example, curl:
+
+```
+curl http://localhost:51310/server/listaas
+```
+
+should give you something like this:
+
+```
+{
+  "aaslist": [
+    "0 : ExampleMotor : [IRI] http://customer.com/aas/9175_7013_7091_9168 : ./aasxs/Example_AAS_ServoDCMotor_21.aasx"
+  ]
+}
+```
+
+As you can see, we already provide an example AASX in the container.
+For a more thorough demo, you might want to copy additional AASX packages
+(*e.g.*, from the [samples][samples]) into the container. Find the container
+ID of your running container with:
+
+```
+docker ps
+```
+
+Then use `docker cp` to copy the AASX packages into the `aasxs` directory
+(assuming your docker container ID is `70fe45f1f102`):
+
+```
+docker cp /path/to/samples/*.aasx  70fe45f1f102:/AasxServerCore/aasxs
+```
+
+If you demo with `blazor` variant, change the destination path analogously to 
+`AasxServerBlazor`.
+
+Mind that there are many other options for managing containers for custom demos 
+such as [Docker multi-stage builds][multi-stage]
+(using one of our demo images as base), [bind mounts][bind-mounts] *etc*.
+
+[samples]: http://admin-shell-io.com/samples/
+[multi-stage]: https://docs.docker.com/develop/develop-images/multistage-build/
+[bind-mounts]: https://docs.docker.com/storage/bind-mounts/
 
 ### Build Docker Containers for Demonstration on Linux/MacOS
 

--- a/src/AasxServerBlazor/startForDemo.bat
+++ b/src/AasxServerBlazor/startForDemo.bat
@@ -1,1 +1,1 @@
-AasxServerBlazor.exe --rest --data-path aasxs
+AasxServerBlazor.exe --rest --no-security --data-path aasxs

--- a/src/AasxServerBlazor/startForDemo.sh
+++ b/src/AasxServerBlazor/startForDemo.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-dotnet AasxServerBlazor.dll --rest --data-path ./aasxs
+dotnet AasxServerBlazor.dll --rest --no-security --data-path ./aasxs

--- a/src/AasxServerCore/startForDemo.bat
+++ b/src/AasxServerCore/startForDemo.bat
@@ -1,1 +1,1 @@
-AasxServerCore.exe --rest --data-path aasxs
+AasxServerCore.exe --rest --no-security --data-path aasxs

--- a/src/AasxServerCore/startForDemo.sh
+++ b/src/AasxServerCore/startForDemo.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-dotnet AasxServerCore.dll --rest --data-path ./aasxs
+dotnet AasxServerCore.dll --rest --no-security --data-path ./aasxs

--- a/src/docker/Dockerfile-AasxServerBlazor
+++ b/src/docker/Dockerfile-AasxServerBlazor
@@ -10,5 +10,6 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 EXPOSE 51210
 EXPOSE 51310
 COPY --from=build-env /out/AasxServerBlazor/ /AasxServerBlazor/
+COPY ./content-for-demo/ /AasxServerBlazor/
 WORKDIR /AasxServerBlazor
 ENTRYPOINT ["/bin/bash", "-c", "./startForDemo.sh"]

--- a/src/docker/Dockerfile-AasxServerCore
+++ b/src/docker/Dockerfile-AasxServerCore
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
 WORKDIR /src
 
-# Copy everything else and build
+# Copy the source code and build
 COPY ./src/ /src/
 RUN dotnet publish -c Release -o /out/AasxServerCore AasxServerCore
 
@@ -10,5 +10,6 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 EXPOSE 51210
 EXPOSE 51310
 COPY --from=build-env /out/AasxServerCore/ /AasxServerCore/
+COPY ./content-for-demo/ /AasxServerCore/
 WORKDIR /AasxServerCore
 ENTRYPOINT ["/bin/bash", "-c", "./startForDemo.sh"]


### PR DESCRIPTION
This patch changes the dockerfiles so that they include the content
for demonstration and fixes the Readme so that the user are instructed
how to interact with the running container and how to copy additional
files for demonstration.