### PR TITLE
Fix `docker cp` command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Then use `docker cp` to copy the AASX packages into the `aasxs` directory
 (assuming your docker container ID is `70fe45f1f102`):
 
 ```
-docker cp /path/to/samples/*.aasx  70fe45f1f102:/AasxServerCore/aasxs
+docker cp /path/to/aasx/samples/  70fe45f1f102:/AasxServerCore/aasxs/
 ```
 
 If you demo with `blazor` variant, change the destination path analogously to 


### PR DESCRIPTION
The copy command listed in the Readme had an error -- `docker cp` does
not support wildcards (`docker cp /some/path/*.aasx ...`). This patch
fixes the command so that it only copies the content of the directory
without any globbing with wildcards.