### PR TITLE
Publish dockers only on master and releases

### DIFF
--- a/.github/workflows/build-and-publish-docker-images.yml
+++ b/.github/workflows/build-and-publish-docker-images.yml
@@ -2,6 +2,12 @@ name: Build-and-publish-docker-images-workflow
 
 on:
   push
+    branches:
+      - main
+      - master
+
+  release:
+    types: [published]
 
 jobs:
   Build-and-publish-docker-images:


### PR DESCRIPTION
This patch makes the workflow for building and publishing docker images
run only if there are pushes to master or new releases. Previously, we
ran on every push which polluted DockerHub repository with unnecessary
images.