### PR TITLE
Unify ARM dockerfiles on ASP.NET for Blazor

### DIFF
--- a/src/docker/Dockerfile-AasxServerBlazor-arm32
+++ b/src/docker/Dockerfile-AasxServerBlazor-arm32
@@ -10,7 +10,6 @@ RUN dotnet restore -r linux-arm
 
 RUN dotnet publish -c Release -o /out/AasxServerBlazor AasxServerBlazor -r linux-arm --self-contained false --no-restore
 
-# FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim-arm32v7
 EXPOSE 51210
 EXPOSE 51310

--- a/src/docker/Dockerfile-AasxServerBlazor-arm64
+++ b/src/docker/Dockerfile-AasxServerBlazor-arm64
@@ -10,7 +10,7 @@ RUN dotnet restore -r linux-arm64
 
 RUN dotnet publish -c Release -o /out/AasxServerBlazor AasxServerBlazor -r linux-arm64 --self-contained false --no-restore
 
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim-arm64v8
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim-arm64v8
 EXPOSE 51210
 EXPOSE 51310
 COPY --from=build-env /out/AasxServerBlazor/ /AasxServerBlazor/


### PR DESCRIPTION
The dockerfile for ARM 32-bit and ARM 64-bit diverged since the former
used ASP.NET base image and the latter slim dotnet core image. Blazor
requires ASP.NET *runtime* and we had problems running Blazor
aasx-server on dotnet core base image.