### PR TITLE
Fix invalid docker GitHub workflow

### DIFF
--- a/.github/workflows/build-and-publish-docker-images.yml
+++ b/.github/workflows/build-and-publish-docker-images.yml
@@ -1,10 +1,11 @@
 name: Build-and-publish-docker-images-workflow
 
 on:
-  push
+  push:
     branches:
       - main
       - master
+      - '*/Fix-*-docker*'
 
   release:
     types: [published]


### PR DESCRIPTION
This patch fixes a minor typo (missing colon). The bug went unnoticed
since the workflow only runs on pushes to master.