### PR TITLE
Magnus redeker/its owl te dz rest instantiate aas template

### DIFF
--- a/src/AasxServerStandardBib/AasxFileInfo.cs
+++ b/src/AasxServerStandardBib/AasxFileInfo.cs
@@ -5,5 +5,6 @@
         public string path { get; set; } = null;
         public bool instantiateTemplate { get; set; } = false;
         public string identificationSuffix { get; set; } = null;
+        public bool instantiateSubmodelsIdShort { get; set; } = false;
     }
 }

--- a/src/AasxServerStandardBib/AasxFileInfo.cs
+++ b/src/AasxServerStandardBib/AasxFileInfo.cs
@@ -4,7 +4,7 @@
     {
         public string path { get; set; } = null;
         public bool instantiateTemplate { get; set; } = false;
-        public string identificationSuffix { get; set; } = null;
+        public string instancesIdentificationSuffix { get; set; } = null;
         public bool instantiateSubmodelsIdShort { get; set; } = false;
     }
 }

--- a/src/AasxServerStandardBib/AasxFileInfo.cs
+++ b/src/AasxServerStandardBib/AasxFileInfo.cs
@@ -2,6 +2,8 @@
 {
     public class AasxFileInfo
     {
-        public string path = null;
+        public string path { get; set; } = null;
+        public bool instantiateTemplate { get; set; } = false;
+        public string identificationSuffix { get; set; } = null;
     }
 }

--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -833,16 +833,16 @@ namespace AasxRestServerLibrary
 
             if (file.instantiateTemplate)
             {
-                if (file.identificationSuffix == null)
+                if (file.instancesIdentificationSuffix == null)
                 {
                     context.Response.SendResponse(HttpStatusCode.BadRequest, $"Received no identification suffix. Aborting...");
                     return;
                 }
                 else
                 {
-                    Console.WriteLine("EvalPutAasxOnServer: file.identificationSuffix = " + file.identificationSuffix);
-                    string idSuffix = "#" + file.identificationSuffix;
-                    string idShortSuffix = "_" + file.identificationSuffix;
+                    Console.WriteLine("EvalPutAasxOnServer: file.instancesIdentificationSuffix = " + file.instancesIdentificationSuffix);
+                    string idSuffix = "#" + file.instancesIdentificationSuffix;
+                    string idShortSuffix = "_" + file.instancesIdentificationSuffix;
                     Console.WriteLine("EvalPutAasxOnServer: idSuffix = " + idSuffix);
                     Console.WriteLine("EvalPutAasxOnServer: idShortSuffix = " + idShortSuffix);
 

--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -841,22 +841,18 @@ namespace AasxRestServerLibrary
                 else
                 {
                     Console.WriteLine("EvalPutAasxOnServer: file.instancesIdentificationSuffix = " + file.instancesIdentificationSuffix);
-                    string idSuffix = "#" + file.instancesIdentificationSuffix;
-                    string idShortSuffix = "_" + file.instancesIdentificationSuffix;
-                    Console.WriteLine("EvalPutAasxOnServer: idSuffix = " + idSuffix);
-                    Console.WriteLine("EvalPutAasxOnServer: idShortSuffix = " + idShortSuffix);
-
+                    
                     // instantiate aas
                     foreach (var aas in aasEnv.AasEnv.AdministrationShells)
                     {
-                        aas.idShort += idShortSuffix;
-                        aas.identification.id += idSuffix;
-                        aas.assetRef[0].value += idSuffix;
+                        aas.idShort += file.instancesIdentificationSuffix;
+                        aas.identification.id += file.instancesIdentificationSuffix;
+                        aas.assetRef[0].value += file.instancesIdentificationSuffix;
                         foreach (var smref in aas.submodelRefs)
                         {
                             foreach (var key in smref.Keys)
                             {
-                                key.value += idSuffix;
+                                key.value += file.instancesIdentificationSuffix;
                             }
                         }
                     }
@@ -864,22 +860,22 @@ namespace AasxRestServerLibrary
                     // instantiate asset
                     foreach (var asset in aasEnv.AasEnv.Assets)
                     {
-                        asset.idShort += idShortSuffix;
-                        asset.identification.id += idSuffix;
+                        asset.idShort += file.instancesIdentificationSuffix;
+                        asset.identification.id += file.instancesIdentificationSuffix;
                     }
 
                     // instantiate submodel
                     foreach (var submodel in aasEnv.AasEnv.Submodels)
                     {
-                        submodel.identification.id += idSuffix;
+                        submodel.identification.id += file.instancesIdentificationSuffix;
                         if (file.instantiateSubmodelsIdShort)
                         {
-                            submodel.idShort += idShortSuffix;
+                            submodel.idShort += file.instancesIdentificationSuffix;
                         }
                     }
                 }
             }
-
+            
             string aasIdShort = "";
             try
             {

--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -841,46 +841,42 @@ namespace AasxRestServerLibrary
                 else
                 {
                     Console.WriteLine("EvalPutAasxOnServer: file.identificationSuffix = " + file.identificationSuffix);
-                    /*if (!file.identificationSuffix.StartsWith("#"))
-                    {
-                        file.identificationSuffix = "#" + file.identificationSuffix;
-                    }*/
-                    Console.WriteLine("EvalPutAasxOnServer: file.identificationSuffix = " + file.identificationSuffix);
+                    string idSuffix = "#" + file.identificationSuffix;
+                    string idShortSuffix = "_" + file.identificationSuffix;
+                    Console.WriteLine("EvalPutAasxOnServer: idSuffix = " + idSuffix);
+                    Console.WriteLine("EvalPutAasxOnServer: idShortSuffix = " + idShortSuffix);
 
                     // instantiate aas
                     foreach (var aas in aasEnv.AasEnv.AdministrationShells)
                     {
-                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
-                        aas.idShort += file.identificationSuffix;
-                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
-                        aas.identification.id += file.identificationSuffix;
-                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
-                        aas.assetRef[0].value += file.identificationSuffix;
-                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
+                        aas.idShort += idShortSuffix;
+                        aas.identification.id += idSuffix;
+                        aas.assetRef[0].value += idSuffix;
                         foreach (var smref in aas.submodelRefs)
                         {
                             foreach (var key in smref.Keys)
                             {
-                                key.value += file.identificationSuffix;
+                                key.value += idSuffix;
                             }
                         }
-                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
                     }
 
                     // instantiate asset
                     foreach (var asset in aasEnv.AasEnv.Assets)
                     {
-                        asset.idShort += file.identificationSuffix;
-                        asset.identification.id += file.identificationSuffix;
+                        asset.idShort += idShortSuffix;
+                        asset.identification.id += idSuffix;
                     }
-                    Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aasEnv.AasEnv.AdministrationShells[0].idShort);
-
+                    
                     // instantiate submodel
                     foreach (var submodel in aasEnv.AasEnv.Submodels)
                     {
-                        submodel.identification.id += file.identificationSuffix;
+                        submodel.identification.id += idSuffix;
+                        if (file.instantiateSubmodelsIdShort)
+                        {
+                            submodel.idShort += idShortSuffix;
+                        }
                     }
-                    Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aasEnv.AasEnv.AdministrationShells[0].idShort);
                 }
             }
 

--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -841,7 +841,7 @@ namespace AasxRestServerLibrary
                 else
                 {
                     Console.WriteLine("EvalPutAasxOnServer: file.instancesIdentificationSuffix = " + file.instancesIdentificationSuffix);
-                    
+
                     // instantiate aas
                     foreach (var aas in aasEnv.AasEnv.AdministrationShells)
                     {
@@ -875,7 +875,7 @@ namespace AasxRestServerLibrary
                     }
                 }
             }
-            
+
             string aasIdShort = "";
             try
             {

--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -867,7 +867,7 @@ namespace AasxRestServerLibrary
                         asset.idShort += idShortSuffix;
                         asset.identification.id += idSuffix;
                     }
-                    
+
                     // instantiate submodel
                     foreach (var submodel in aasEnv.AasEnv.Submodels)
                     {

--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -831,6 +831,59 @@ namespace AasxRestServerLibrary
                 return;
             }
 
+            if (file.instantiateTemplate)
+            {
+                if (file.identificationSuffix == null)
+                {
+                    context.Response.SendResponse(HttpStatusCode.BadRequest, $"Received no identification suffix. Aborting...");
+                    return;
+                }
+                else
+                {
+                    Console.WriteLine("EvalPutAasxOnServer: file.identificationSuffix = " + file.identificationSuffix);
+                    /*if (!file.identificationSuffix.StartsWith("#"))
+                    {
+                        file.identificationSuffix = "#" + file.identificationSuffix;
+                    }*/
+                    Console.WriteLine("EvalPutAasxOnServer: file.identificationSuffix = " + file.identificationSuffix);
+
+                    // instantiate aas
+                    foreach (var aas in aasEnv.AasEnv.AdministrationShells)
+                    {
+                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
+                        aas.idShort += file.identificationSuffix;
+                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
+                        aas.identification.id += file.identificationSuffix;
+                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
+                        aas.assetRef[0].value += file.identificationSuffix;
+                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
+                        foreach (var smref in aas.submodelRefs)
+                        {
+                            foreach (var key in smref.Keys)
+                            {
+                                key.value += file.identificationSuffix;
+                            }
+                        }
+                        Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aas.idShort);
+                    }
+
+                    // instantiate asset
+                    foreach (var asset in aasEnv.AasEnv.Assets)
+                    {
+                        asset.idShort += file.identificationSuffix;
+                        asset.identification.id += file.identificationSuffix;
+                    }
+                    Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aasEnv.AasEnv.AdministrationShells[0].idShort);
+
+                    // instantiate submodel
+                    foreach (var submodel in aasEnv.AasEnv.Submodels)
+                    {
+                        submodel.identification.id += file.identificationSuffix;
+                    }
+                    Console.WriteLine("EvalPutAasxOnServer: aas.idShort = " + aasEnv.AasEnv.AdministrationShells[0].idShort);
+                }
+            }
+
             string aasIdShort = "";
             try
             {

--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -914,6 +914,7 @@ namespace AasxRestServerLibrary
 
         public void EvalPutAasxToFilesystem(IHttpContext context, string aasid)
         {
+            Console.WriteLine("EvalPutAasxToFilesystem");
             // first check
             if (context.Request.Payload == null || context.Request.ContentType != ContentType.JSON)
             {
@@ -922,6 +923,7 @@ namespace AasxRestServerLibrary
             }
 
             AasxFileInfo file = Newtonsoft.Json.JsonConvert.DeserializeObject<AasxFileInfo>(context.Request.Payload);
+            Console.WriteLine("EvalPutAasxToFilesystem: " + JsonConvert.SerializeObject(file.path));
             if (!file.path.ToLower().EndsWith(".aasx"))
             {
                 context.Response.SendResponse(HttpStatusCode.BadRequest, $"Not a path ending with \".aasx\"...:{file.path}. Aborting...");
@@ -941,14 +943,14 @@ namespace AasxRestServerLibrary
                 try
                 {
                     Packages[findAasReturn.iPackage].SaveAs(file.path, false, AdminShellPackageEnv.PreferredFormat.Json, null);
+                    SendTextResponse(context, "OK (saved)");
+                    return;
                 }
                 catch (Exception ex)
                 {
                     context.Response.SendResponse(HttpStatusCode.BadRequest, $"Cannot save in {file.path}. Aborting... {ex.Message}");
                     return;
                 }
-                SendTextResponse(context, "OK (saved)");
-                return;
             }
         }
 

--- a/src/AasxServerStandardBib/AdminShellPackageEnv.cs
+++ b/src/AasxServerStandardBib/AdminShellPackageEnv.cs
@@ -403,6 +403,7 @@ namespace AdminShellNS
 
         public bool SaveAs(string fn, bool writeFreshly = false, PreferredFormat prefFmt = PreferredFormat.None, MemoryStream useMemoryStream = null)
         {
+            Console.WriteLine("SaveAs: " + fn);
             if (fn.ToLower().EndsWith(".xml"))
             {
                 // save only XML


### PR DESCRIPTION
Hi Andreas,
I have adapted the function EvalPutAasxOnServer() in AasxHttpContextHelper.cs.
Now it is possible to load and instatiate an AAS-template by appending instancesIdentificationSuffix to identification.id and idShort of AAS, Asset and Submodels.
Regards,
Magnus
