### PR TITLE
set Program.envFileName in EvalPutAasxOnServer() and EvalPutAasxToFil…

### DIFF
--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -926,6 +926,7 @@ namespace AasxRestServerLibrary
                     if (this.Packages[envi] == null)
                     {
                         this.Packages[envi] = aasEnv;
+                        Program.envFileName[envi] = file.path;
                         context.Response.StatusCode = HttpStatusCode.Ok;
                         SendTextResponse(context, "OK (new, index=" + envi + ")");
                         return;
@@ -938,6 +939,7 @@ namespace AasxRestServerLibrary
             else
             {
                 Packages[findAasReturn.iPackage] = aasEnv;
+                Program.envFileName[findAasReturn.iPackage] = file.path;
                 context.Response.StatusCode = HttpStatusCode.Ok;
                 SendTextResponse(context, "OK (update, index=" + findAasReturn.iPackage + ")");
                 return;
@@ -992,6 +994,7 @@ namespace AasxRestServerLibrary
                 try
                 {
                     Packages[findAasReturn.iPackage].SaveAs(file.path, false, AdminShellPackageEnv.PreferredFormat.Json, null);
+                    Program.envFileName[findAasReturn.iPackage] = file.path;
                     context.Response.StatusCode = HttpStatusCode.Ok;
                     SendTextResponse(context, "OK (saved)");
                     return;


### PR DESCRIPTION
Hi Andreas,
I have adapted the functions EvalPutAasxOnServer() and EvalPutAasxToFilesystem() in AasxHttpContextHelper.cs.
Now the "AASX File Repository .. - Connect HTTP/REST repository .." in the AASXPackageExplorer functions also for AASs in the AASXServer that were saved/loaded by these functions.
Best regards,
Magnus