### PR TITLE
Make blazor docker rely on asp.net docker

### DIFF
--- a/src/docker/Dockerfile-AasxServerBlazor
+++ b/src/docker/Dockerfile-AasxServerBlazor
@@ -7,7 +7,7 @@ COPY ./src/ /repo/src/
 COPY ./LICENSE.txt /repo/
 RUN dotnet publish -c Release -o /out/AasxServerBlazor AasxServerBlazor
 
-FROM mcr.microsoft.com/dotnet/runtime:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
 EXPOSE 51210
 EXPOSE 51310
 COPY --from=build-env /out/AasxServerBlazor/ /AasxServerBlazor/


### PR DESCRIPTION
The docker image for the demo of the blazor server needs to rely on
ASP.NET, but we built it only on top of .NET runtime.

This patch rewires the blazor image to have ASP.NET runtime included.