### PR TITLE
Include embeddedDataSpecifications

### DIFF
--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -780,7 +780,7 @@ namespace AasxRestServerLibrary
 
             // access the first AAS
             var findAasReturn = this.FindAAS(aasid, context.Request.QueryString, context.Request.RawUrl);
-            if (findAasReturn.aas == null)
+            if (findAasReturn == null || findAasReturn.aas == null)
             {
                 context.Response.SendResponse(HttpStatusCode.NotFound, $"No AAS with id '{aasid}' found.");
                 return;
@@ -2695,6 +2695,7 @@ namespace AasxRestServerLibrary
                 o.shortName = cd.GetDefaultShortName();
                 o.identification = cd.identification;
                 o.isCaseOf = cd.IsCaseOf;
+                o.embeddedDataSpecifications = cd.JsonEmbeddedDataSpecifications;
 
                 // add
                 res.Add(o);


### PR DESCRIPTION
A small addition to add the definitions and preferred names of concept descriptions to the output of the `/aas/(id)/cds/` REST call.

Also fixes a bug when requesting an AAS by ID that was not found.