### PR TITLE
Base64URL-encoding for fragments

### DIFF
--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -27,6 +27,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using HttpStatusCode = Grapevine.Shared.HttpStatusCode;
+using Microsoft.IdentityModel.Tokens;
 
 /* Copyright (c) 2018-2019 Festo AG & Co. KG <https://www.festo.com/net/de_de/Forms/web/contact_international>, author: Michael Hoffmeister
 
@@ -2345,6 +2346,17 @@ namespace AasxRestServerLibrary
         public void EvalGetSubmodelElementFragment(IHttpContext context, string aasid, string smid, string[] elemids, string fragmentType, string fragment)
         {
 
+            string decodedFragment;
+            try
+            {
+                decodedFragment = Base64UrlEncoder.Decode(fragment);
+            }
+            catch (FormatException)
+            {
+                context.Response.SendResponse(HttpStatusCode.BadRequest, $"Unable to Base64URL-decode fragment '{fragment}'!");
+                return;
+            }
+
             // access the first AAS
             var findAasReturn = this.FindAAS(aasid, context.Request.QueryString, context.Request.RawUrl);
             if (findAasReturn.aas == null)
@@ -2390,17 +2402,17 @@ namespace AasxRestServerLibrary
                 case "aml":
                 case "aml20":
                 case "aml21":
-                    this.EvalGetAMLFragment(context, packageStream, fragment);
+                    this.EvalGetAMLFragment(context, packageStream, decodedFragment);
                     break;
                 case "xml":
-                    this.EvalGetXMLFragment(context, packageStream, fragment);
+                    this.EvalGetXMLFragment(context, packageStream, decodedFragment);
                     break;
                 case "zip":
-                    this.EvalGetZIPFragment(context, packageStream, fragment);
+                    this.EvalGetZIPFragment(context, packageStream, decodedFragment);
                     break;
                 case "xls":
                 case "xlsx":
-                    this.EvalGetXLSFragment(context, packageStream, fragment);
+                    this.EvalGetXLSFragment(context, packageStream, decodedFragment);
                     break;
                 // possibility to add support for more fragment types in the future
                 default:

--- a/src/AasxServerStandardBib/AasxHttpContextHelperAmlExtensions.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelperAmlExtensions.cs
@@ -89,7 +89,7 @@ namespace AasxRestServerLibrary
         {
             CAEXBasicObject fragmentObject;
 
-            String caexPath = HttpUtility.UrlDecode(amlFragment.Trim('/'));
+            String caexPath = amlFragment.Trim('/');
             if (caexPath.Length == 0)
             {
                 fragmentObject = caexDocument.CAEXFile;

--- a/src/AasxServerStandardBib/AasxHttpContextHelperXlsExtensions.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelperXlsExtensions.cs
@@ -66,7 +66,7 @@ namespace AasxRestServerLibrary
 
         private static object FindFragmentObject(XLWorkbook workbook, string xlsFragment)
         {
-            String xlsExpression = HttpUtility.UrlDecode(xlsFragment.Trim('/'));
+            String xlsExpression = xlsFragment.Trim('/');
 
             try
             {

--- a/src/AasxServerStandardBib/AasxHttpContextHelperXmlExtensions.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelperXmlExtensions.cs
@@ -93,7 +93,7 @@ namespace AasxRestServerLibrary
 
         private static XPathNodeIterator FindFragmentObjects(XmlDocument xmlDocument, string xmlFragment)
         {
-            var xPath = HttpUtility.UrlDecode(xmlFragment.Trim('/'));
+            var xPath = xmlFragment.Trim('/');
 
             XPathNavigator navigator = xmlDocument.CreateNavigator();
             XPathExpression query;

--- a/src/AasxServerStandardBib/AasxHttpContextHelperZipExtensions.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelperZipExtensions.cs
@@ -92,7 +92,7 @@ namespace AasxRestServerLibrary
         private static dynamic FindFragmentObject(ZipArchive archive, string zipFragment)
         {
             zipFragment = zipFragment.Trim('/');
-            
+
             if (zipFragment.Length == 0)
             {
                 return zipFragment;

--- a/src/AasxServerStandardBib/AasxHttpContextHelperZipExtensions.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelperZipExtensions.cs
@@ -91,16 +91,16 @@ namespace AasxRestServerLibrary
 
         private static dynamic FindFragmentObject(ZipArchive archive, string zipFragment)
         {
-            var zipPath = HttpUtility.UrlDecode(zipFragment.Trim('/'));
-
-            if (zipPath.Length == 0)
+            zipFragment = zipFragment.Trim('/');
+            
+            if (zipFragment.Length == 0)
             {
-                return zipPath;
+                return zipFragment;
             }
 
             try
             {
-                var entry = archive.GetEntry(zipPath);
+                var entry = archive.GetEntry(zipFragment);
 
                 if (entry != null)
                 {
@@ -111,17 +111,17 @@ namespace AasxRestServerLibrary
                     else
                     {
                         // path represents a directory
-                        return zipPath;
+                        return zipFragment;
                     }
                 }
                 else
                 {
                     // might be a directory that does not have its own entry
-                    var entries = archive.Entries.Where(e => e.FullName.StartsWith(zipPath));
+                    var entries = archive.Entries.Where(e => e.FullName.StartsWith(zipFragment));
 
                     if (entries.Count() > 0)
                     {
-                        return zipPath;
+                        return zipFragment;
                     }
                     else
                     {


### PR DESCRIPTION
Previously, fragments were either not encoded at all (AML) or URL-encoded (XML, etc.). In order to be more compliant with the latest version of DotAAS Part 2 and facilitate decoding of fragments, all fragments now need to be Base64URL-encoded.

Base64URL-decoding is now done separately and the decoded fragment is passed to the type-specific routines.