### PR TITLE
Support for nested fragments

### DIFF
--- a/src/AasxServerStandardBib/AasxHttpContextHelper.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelper.cs
@@ -2375,19 +2375,8 @@ namespace AasxRestServerLibrary
             packageStream.Close();
         }
 
-        public void EvalGetSubmodelElementFragment(IHttpContext context, string aasid, string smid, string[] elemids, string fragmentType, string fragment)
+        public void EvalGetSubmodelElementFragment(IHttpContext context, string aasid, string smid, string[] elemids, List<(string fragmentType, string fragmentValue)> nestedFragments)
         {
-
-            string decodedFragment;
-            try
-            {
-                decodedFragment = Base64UrlEncoder.Decode(fragment);
-            }
-            catch (FormatException)
-            {
-                context.Response.SendResponse(HttpStatusCode.BadRequest, $"Unable to Base64URL-decode fragment '{fragment}'!");
-                return;
-            }
 
             // access the first AAS
             var findAasReturn = this.FindAAS(aasid, context.Request.QueryString, context.Request.RawUrl);
@@ -2429,32 +2418,84 @@ namespace AasxRestServerLibrary
                 return;
             }
 
-            switch (fragmentType)
-            {
-                case "aml":
-                case "aml20":
-                case "aml21":
-                    this.EvalGetAMLFragment(context, packageStream, decodedFragment);
-                    break;
-                case "xml":
-                    this.EvalGetXMLFragment(context, packageStream, decodedFragment);
-                    break;
-                case "zip":
-                    this.EvalGetZIPFragment(context, packageStream, decodedFragment);
-                    break;
-                case "xls":
-                case "xlsx":
-                    this.EvalGetXLSFragment(context, packageStream, decodedFragment);
-                    break;
-                // possibility to add support for more fragment types in the future
-                default:
-                    context.Response.SendResponse(
-                        Grapevine.Shared.HttpStatusCode.NotFound,
-                        $"Unsupported fragment format. Fragment type '" + fragmentType + "' is not supported.");
-                    break;
-            }
+            EvalGetSubmodelElementFragment(context, packageStream, nestedFragments);
 
             packageStream.Close();
+        }
+
+        private void EvalGetSubmodelElementFragment(IHttpContext context, Stream fileStream, List<(string fragmentType, string fragmentValue)> nestedFragments)
+        {
+            var fragment = nestedFragments.First();
+
+            string decodedFragment;
+            try
+            {
+                decodedFragment = Base64UrlEncoder.Decode(fragment.fragmentValue);
+            }
+            catch (FormatException)
+            {
+                context.Response.SendResponse(HttpStatusCode.BadRequest, $"Unable to Base64URL-decode fragment '{fragment}'!");
+                return;
+            }
+
+            var otherFragments = nestedFragments.Skip(1).ToList();
+            if (otherFragments.Count == 0)
+            {
+                switch (fragment.fragmentType)
+                {
+                    case "aml":
+                    case "aml20":
+                    case "aml21":
+                        this.EvalGetAMLFragment(context, fileStream, decodedFragment);
+                        break;
+                    case "xml":
+                        this.EvalGetXMLFragment(context, fileStream, decodedFragment);
+                        break;
+                    case "zip":
+                        this.EvalGetZIPFragment(context, fileStream, decodedFragment);
+                        break;
+                    case "xls":
+                    case "xlsx":
+                        this.EvalGetXLSFragment(context, fileStream, decodedFragment);
+                        break;
+                    // possibility to add support for more fragment types in the future
+                    default:
+                        context.Response.SendResponse(
+                            Grapevine.Shared.HttpStatusCode.NotFound,
+                            $"Unsupported fragment format. Fragment type '" + fragment.fragmentType + "' is not supported.");
+                        break;
+                }
+            }
+            else
+            {
+                // the fragment represents an intermediate fragment in a set of nested fragment; consequently, evaluation
+                // is expected to return a stream to a file that will then be used for evaluation of the next fragment
+                Stream nestedFileStream = null;
+                switch (fragment.fragmentType)
+                {
+                    case "zip":
+                        nestedFileStream = this.EvalGetZIPFragmentAsStream(context, fileStream, decodedFragment);
+                        break;
+                    // possibility to add support for more fragment types in the future
+                    default:
+                        context.Response.SendResponse(
+                            Grapevine.Shared.HttpStatusCode.NotFound,
+                            $"Unsupported fragment format. Fragment type '" + fragment.fragmentType + "' does not support nested fragments.");
+                        break;
+                }
+
+                if (nestedFileStream == null)
+                {
+                    context.Response.SendResponse(
+                            Grapevine.Shared.HttpStatusCode.NotFound,
+                            $"Unable to retrieve nested file for fragment '" + fragment.fragmentValue + "'.");
+                    return;
+                }
+
+                EvalGetSubmodelElementFragment(context, nestedFileStream, otherFragments);
+
+                nestedFileStream.Close();
+            }
         }
 
         public void EvalPutSubmodelElementContents(IHttpContext context, string aasid, string smid, string[] elemids)

--- a/src/AasxServerStandardBib/AasxHttpContextHelperXmlExtensions.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelperXmlExtensions.cs
@@ -34,7 +34,7 @@ namespace AasxRestServerLibrary
 
                 if (level == "core")
                 {
-                    foreach(var fragmentObject in fragmentObjects)
+                    foreach (var fragmentObject in fragmentObjects)
                     {
                         if (fragmentObject.NodeType == XmlNodeType.Element)
                         {
@@ -51,7 +51,7 @@ namespace AasxRestServerLibrary
                     }
 
                     var fragmentObject = fragmentObjects.First();
-                    
+
                     if (fragmentObject.NodeType != XmlNodeType.Element)
                     {
                         throw new XmlFragmentEvaluationException($"Fragment evaluation did not return an Element but a(n) " + fragmentObject.NodeType + "!");
@@ -113,7 +113,8 @@ namespace AasxRestServerLibrary
             try
             {
                 nodes = ((IEnumerable<object>)result).Cast<XObject>();
-            } catch
+            }
+            catch
             {
                 throw new XmlFragmentEvaluationException($"Evaluating xPath query '" + xPath + "' did not return a node list.");
             }
@@ -152,7 +153,7 @@ namespace AasxRestServerLibrary
                 // select all children's children (the elements to be deleted)
                 XElement nodeToDelete;
 
-                while((nodeToDelete = fragmentObject.XPathSelectElement("./*/*")) != null)
+                while ((nodeToDelete = fragmentObject.XPathSelectElement("./*/*")) != null)
                 {
                     nodeToDelete.Remove();
                 }
@@ -220,8 +221,10 @@ namespace AasxRestServerLibrary
             IEnumerable<XObject> nodeList;
             try
             {
-                nodeList = (IEnumerable<XObject>) value;
-            } catch {
+                nodeList = (IEnumerable<XObject>)value;
+            }
+            catch
+            {
                 throw new XmlFragmentEvaluationException("Unable to convert object to IEnumerable<XObject>: " + value);
             }
 
@@ -237,11 +240,12 @@ namespace AasxRestServerLibrary
             if (nodeList.Count() == 1)
             {
                 return ConvertToJson(nodeList.First());
-            } else
+            }
+            else
             {
                 JArray result = new JArray();
 
-                foreach(var node in nodeList)
+                foreach (var node in nodeList)
                 {
                     result.Add(ConvertToJson(node));
                 }
@@ -295,11 +299,13 @@ namespace AasxRestServerLibrary
                 copy.Add(original.Nodes().Where(n => n.NodeType != XmlNodeType.Comment).Select(el => RemoveAllNamespacesAndComments(el)));
 
                 return copy;
-            } else if (xmlObject is XAttribute)
+            }
+            else if (xmlObject is XAttribute)
             {
                 XAttribute original = xmlObject as XAttribute;
                 return new XAttribute(original.Name.LocalName, original.Value);
-            } else
+            }
+            else
             {
                 return xmlObject;
             }
@@ -332,7 +338,7 @@ namespace AasxRestServerLibrary
         {
             var paths = new List<string>();
             paths.Add(baseXpath);
-            
+
             Dictionary<string, List<XElement>> childDict = GetChildrenSortedByName(xmlElement);
 
             foreach (var key in childDict?.Keys)

--- a/src/AasxServerStandardBib/AasxHttpContextHelperXmlExtensions.cs
+++ b/src/AasxServerStandardBib/AasxHttpContextHelperXmlExtensions.cs
@@ -25,16 +25,8 @@ namespace AasxRestServerLibrary
         {
             try
             {
-                XmlDocument xmlDocument = LoadXmlDocument(xmlFileStream);
-                XPathNodeIterator fragmentObjectsIterator = FindFragmentObjects(xmlDocument, xmlFragment);
-
-                if (fragmentObjectsIterator.Count > 1)
-                {
-                    throw new XmlFragmentEvaluationException($"Fragment evaluation did return multiple XML elements. Only xPath expressions returning a single element are supported.");
-                }
-
-                fragmentObjectsIterator.MoveNext();
-                XPathNavigator fragmentObject = fragmentObjectsIterator.Current;
+                XDocument xmlDocument = LoadXmlDocument(xmlFileStream);
+                IEnumerable<XObject> fragmentObjects = FindFragmentObjects(xmlDocument, xmlFragment);
 
                 var content = context.Request.QueryString.Get("content") ?? "normal";
                 var level = context.Request.QueryString.Get("level") ?? "deep";
@@ -42,26 +34,37 @@ namespace AasxRestServerLibrary
 
                 if (level == "core")
                 {
-                    DeeplyNestedXmlElementsRemover.RemoveDeeplements(fragmentObject);
+                    foreach(var fragmentObject in fragmentObjects)
+                    {
+                        if (fragmentObject.NodeType == XmlNodeType.Element)
+                        {
+                            RemoveDeeplements(fragmentObject as XElement);
+                        }
+                    }
                 }
 
                 if (content == "xml")
                 {
+                    if (fragmentObjects.Count() > 1)
+                    {
+                        throw new XmlFragmentEvaluationException($"Fragment evaluation did return multiple XML elements. Only xPath expressions returning a single element are supported when returning xml content.");
+                    }
 
-                    if (fragmentObject.NodeType != XPathNodeType.Element)
+                    var fragmentObject = fragmentObjects.First();
+                    
+                    if (fragmentObject.NodeType != XmlNodeType.Element)
                     {
                         throw new XmlFragmentEvaluationException($"Fragment evaluation did not return an Element but a(n) " + fragmentObject.NodeType + "!");
                     }
-                    XElement xmlElement = XElement.Parse(fragmentObject.OuterXml);
 
-                    SendXmlResponse(context, xmlElement);
+                    SendXmlResponse(context, fragmentObject as XElement);
 
                 }
                 else
                 {
 
                     JsonConverter converter = new XmlJsonConverter(xmlFragment, content, extent);
-                    string json = JsonConvert.SerializeObject(fragmentObject, Newtonsoft.Json.Formatting.Indented, converter);
+                    string json = JsonConvert.SerializeObject(fragmentObjects, Newtonsoft.Json.Formatting.Indented, converter);
 
                     SendJsonResponse(context, json);
                 }
@@ -77,13 +80,11 @@ namespace AasxRestServerLibrary
             }
         }
 
-        private static XmlDocument LoadXmlDocument(Stream xmlFileStream)
+        private static XDocument LoadXmlDocument(Stream xmlFileStream)
         {
             try
             {
-                var doc = new XmlDocument();
-                doc.Load(xmlFileStream);
-                return doc;
+                return XDocument.Load(xmlFileStream);
             }
             catch
             {
@@ -91,23 +92,43 @@ namespace AasxRestServerLibrary
             }
         }
 
-        private static XPathNodeIterator FindFragmentObjects(XmlDocument xmlDocument, string xmlFragment)
+        private static IEnumerable<XObject> FindFragmentObjects(XDocument xmlDocument, string xmlFragment)
         {
-            var xPath = xmlFragment.Trim('/');
+            // select the root element if the fragment is empty
+            var xPath = (xmlFragment == null || xmlFragment.Length == 0) ? "/*" : xmlFragment;
 
-            XPathNavigator navigator = xmlDocument.CreateNavigator();
-            XPathExpression query;
+            XmlNamespaceManager manager = CreateNamespaceManager(xmlDocument);
 
+            object result;
             try
             {
-                query = navigator.Compile(xPath);
+                result = xmlDocument.XPathEvaluate(xPath, manager);
             }
             catch
             {
                 throw new XmlFragmentEvaluationException($"Unable to compile xPath query '" + xPath + "'.");
             }
 
-            // register the namespace prefixes used in the XML document so that they can be used in xPath queries
+            IEnumerable<XObject> nodes;
+            try
+            {
+                nodes = ((IEnumerable<object>)result).Cast<XObject>();
+            } catch
+            {
+                throw new XmlFragmentEvaluationException($"Evaluating xPath query '" + xPath + "' did not return a node list.");
+            }
+
+            if (nodes.Count() == 0)
+            {
+                throw new XmlFragmentEvaluationException($"Evaluating xPath query '" + xPath + "' did not return a result.");
+            }
+
+            return nodes;
+        }
+
+        private static XmlNamespaceManager CreateNamespaceManager(XDocument xmlDocument)
+        {
+            XPathNavigator navigator = xmlDocument.CreateNavigator();
             XmlNamespaceManager manager = new XmlNamespaceManager(navigator.NameTable);
             navigator.MoveToFollowing(XPathNodeType.Element);
             IDictionary<string, string> namespaces = navigator.GetNamespacesInScope(XmlNamespaceScope.All);
@@ -115,17 +136,27 @@ namespace AasxRestServerLibrary
             {
                 manager.AddNamespace(ns.Key, ns.Value);
             }
-            navigator.MoveToRoot();
 
-            query.SetContext(manager);
-            XPathNodeIterator nodes = navigator.Select(query);
+            return manager;
+        }
 
-            if (nodes.Count == 0)
+        /**
+         * A utility method that can be used to remove 'deeply nested elements' from an XML element, i.e. elements that
+         * are descendants but no direct children of the given object(s).
+         */
+        public static void RemoveDeeplements(XNode fragmentObject)
+        {
+
+            if (fragmentObject.NodeType == XmlNodeType.Element)
             {
-                throw new XmlFragmentEvaluationException($"Evaluating xPath query '" + xPath + "' did not return a result.");
-            }
+                // select all children's children (the elements to be deleted)
+                XElement nodeToDelete;
 
-            return nodes;
+                while((nodeToDelete = fragmentObject.XPathSelectElement("./*/*")) != null)
+                {
+                    nodeToDelete.Remove();
+                }
+            }
         }
 
         static void SendJsonResponse(IHttpContext context, string json)
@@ -149,17 +180,6 @@ namespace AasxRestServerLibrary
             context.Response.ContentLength64 = txt.Length;
             context.Response.SendResponse(txt);
         }
-
-        static void SendTextResponse(IHttpContext context, object element, string mimeType = "text/plain")
-        {
-            string txt = element.ToString();
-            context.Response.ContentType = ContentType.TXT;
-            if (mimeType != null)
-                context.Response.Advanced.ContentType = mimeType;
-            context.Response.ContentEncoding = Encoding.UTF8;
-            context.Response.ContentLength64 = txt.Length;
-            context.Response.SendResponse(txt);
-        }
     }
 
     /**
@@ -176,14 +196,14 @@ namespace AasxRestServerLibrary
 
         public XmlJsonConverter(string xmlFragment, string content = "normal", string extent = "withoutBlobValue")
         {
-            this.BaseXpath = HttpUtility.UrlDecode(xmlFragment.Trim('/')); ;
+            this.BaseXpath = xmlFragment;
             this.Content = content;
             this.Extent = extent;
         }
 
         public override bool CanConvert(Type objectType)
         {
-            return typeof(XPathNavigator).IsAssignableFrom(objectType);
+            return typeof(IEnumerable<XObject>).IsAssignableFrom(objectType);
         }
         public override bool CanRead
         {
@@ -197,57 +217,123 @@ namespace AasxRestServerLibrary
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            XPathNavigator navigator = value as XPathNavigator;
-
-            if (navigator == null)
+            IEnumerable<XObject> nodeList;
+            try
             {
-                throw new XmlFragmentEvaluationException("Unable to convert object to XPathNavigator: " + value);
+                nodeList = (IEnumerable<XObject>) value;
+            } catch {
+                throw new XmlFragmentEvaluationException("Unable to convert object to IEnumerable<XObject>: " + value);
             }
 
-            JContainer result;
+            JContainer result = ConvertToJson(nodeList);
+            result.WriteTo(writer);
 
+            return;
+
+        }
+
+        private JContainer ConvertToJson(IEnumerable<XObject> nodeList)
+        {
+            if (nodeList.Count() == 1)
+            {
+                return ConvertToJson(nodeList.First());
+            } else
+            {
+                JArray result = new JArray();
+
+                foreach(var node in nodeList)
+                {
+                    result.Add(ConvertToJson(node));
+                }
+
+                return result;
+            }
+        }
+
+        private JContainer ConvertToJson(XObject node)
+        {
+            JContainer result;
 
             if (Content == "value")
             {
-                result = new JObject();
-                result["value"] = navigator.InnerXml;
+                // in case of a value-only serialization, we remove all comments and namespace-related information,
+                // i.e. namespace declarations, namespace prefixes as well as schema location information
+                var nodeWithoutNamespaces = RemoveAllNamespacesAndComments(node);
+                result = JObject.FromObject(nodeWithoutNamespaces);
+            }
+            else if (Content == "normal")
+            {
+                result = JObject.FromObject(node);
+            }
+            else if (Content == "path")
+            {
+                if (node.NodeType != XmlNodeType.Element)
+                {
+                    throw new XmlFragmentEvaluationException($"Fragment evaluation did not return an Element but a(n) " + node.NodeType + ". This is not supported when returning path information!");
+                }
+
+                var elementXpath = (BaseXpath == null || BaseXpath.Length == 0 || BaseXpath == "/*") ? "/" + GetLocalXpathExpression(node as XElement) : BaseXpath;
+
+                List<string> paths = CollectChildXpathPathsRecursively(node as XElement, elementXpath);
+                result = JArray.FromObject(paths);
             }
             else
             {
-                if (navigator.NodeType != XPathNodeType.Element)
-                {
-                    throw new XmlFragmentEvaluationException($"Unable to convert XML fragment to XElement. Xpath evaluation probably did return a(n) " + navigator.NodeType + " instead!");
-                }
-
-                XElement xmlElement = XElement.Parse(navigator.OuterXml);
-
-                if (Content == "normal")
-                {
-                    result = JObject.FromObject(xmlElement);
-                }
-                else if (Content == "path")
-                {
-
-                    List<string> paths = CollectChildXpathPathsRecursively(xmlElement, BaseXpath);
-                    result = JArray.FromObject(paths);
-                }
-                else
-                {
-                    throw new XmlFragmentEvaluationException("Unsupported content modifier: " + Content);
-                }
+                throw new XmlFragmentEvaluationException("Unsupported content modifier: " + Content);
             }
 
-            result.WriteTo(writer);
-            return;
+            return result;
+        }
 
+        private static XObject RemoveAllNamespacesAndComments(XObject xmlObject)
+        {
+            if (xmlObject is XElement)
+            {
+                XElement original = xmlObject as XElement;
+                XElement copy = new XElement(original.Name.LocalName);
+                copy.Add(original.Attributes().Where(att => !att.IsNamespaceDeclaration && att.Name.LocalName != "schemaLocation").Select(att => RemoveAllNamespacesAndComments(att)));
+                copy.Add(original.Nodes().Where(n => n.NodeType != XmlNodeType.Comment).Select(el => RemoveAllNamespacesAndComments(el)));
+
+                return copy;
+            } else if (xmlObject is XAttribute)
+            {
+                XAttribute original = xmlObject as XAttribute;
+                return new XAttribute(original.Name.LocalName, original.Value);
+            } else
+            {
+                return xmlObject;
+            }
+        }
+
+        private string GetLocalXpathExpression(XElement node)
+        {
+            var nodeName = node.Name;
+            if (nodeName.NamespaceName?.Length == 0)
+            {
+                // the node is not associated with a namespace, so we can simply use the local name as xPath expression
+                return nodeName.LocalName;
+            }
+
+            var ns = nodeName.Namespace;
+            var nsPrefix = node.GetPrefixOfNamespace(ns);
+
+            if (nsPrefix?.Length > 0)
+            {
+                // there is a prefix for the namespace of the node so we can use this for the xPath expression
+                return nsPrefix + ":" + nodeName.LocalName;
+            }
+
+            // the node is in the default namespace (without any prefix); hence, we need to use some special xPath syntax
+            // to be able to adress the node (see https://stackoverflow.com/a/2530023)
+            return "*[namespace-uri()='" + ns.NamespaceName + "' and local-name()='" + nodeName.LocalName + "']";
         }
 
         private List<string> CollectChildXpathPathsRecursively(XElement xmlElement, string baseXpath)
         {
             var paths = new List<string>();
             paths.Add(baseXpath);
-
-            Dictionary<XName, List<XElement>> childDict = GetChildrenSortedByName(xmlElement);
+            
+            Dictionary<string, List<XElement>> childDict = GetChildrenSortedByName(xmlElement);
 
             foreach (var key in childDict?.Keys)
             {
@@ -269,56 +355,26 @@ namespace AasxRestServerLibrary
             return paths;
         }
 
-        private static Dictionary<XName, List<XElement>> GetChildrenSortedByName(XElement xmlElement)
+        private Dictionary<string, List<XElement>> GetChildrenSortedByName(XElement xmlElement)
         {
-            var childDict = new Dictionary<XName, List<XElement>>();
+            var childDict = new Dictionary<string, List<XElement>>();
 
             foreach (var child in xmlElement?.Elements().ToList())
             {
+                var childName = GetLocalXpathExpression(child);
                 List<XElement> childrenWithSameName;
-                if (!childDict.TryGetValue(child.Name, out childrenWithSameName))
+                if (!childDict.TryGetValue(childName, out childrenWithSameName))
                 {
                     childrenWithSameName = new List<XElement>();
                 }
 
                 childrenWithSameName.Add(child);
-                childDict[child.Name] = childrenWithSameName;
+                childDict[childName] = childrenWithSameName;
             }
 
             return childDict;
         }
     }
-
-    /**
-     * A utility class that can be used to remove 'deeply nested elements' from an XML element, i.e. elements that
-     * are descendants but no direct children of the given object(s).
-     */
-    class DeeplyNestedXmlElementsRemover
-    {
-        private DeeplyNestedXmlElementsRemover() { }
-
-        public static void RemoveDeeplements(XPathNavigator fragmentObject)
-        {
-
-            if (fragmentObject.NodeType == XPathNodeType.Element)
-            {
-                XPathNodeIterator nodesToDelete;
-
-                // select all children's children (the elements to be deleted)
-                while ((nodesToDelete = fragmentObject.Select("./*/*")).Count > 0)
-                {
-
-                    nodesToDelete.MoveNext();
-                    if (nodesToDelete.Current.NodeType == XPathNodeType.Element)
-                    {
-                        nodesToDelete.Current.DeleteSelf();
-                    }
-                }
-            }
-        }
-    }
-
-
 
     /**
      * An exception that indicates that something went wrong while evaluating an XML fragment.

--- a/src/AasxServerStandardBib/AasxRestServer.cs
+++ b/src/AasxServerStandardBib/AasxRestServer.cs
@@ -1673,7 +1673,7 @@ namespace AasxRestServerLibrary
 
                     List<(string fragmentType, string fragment)> nestedFragments = new List<(string, string)>();
 
-                    foreach(var fragment in nestedFragmentStrings)
+                    foreach (var fragment in nestedFragmentStrings)
                     {
                         var parts = fragment.Split(new[] { '/' }, 2);
                         nestedFragments.Add((parts[0], parts[1].TrimEnd(new[] { '/' })));

--- a/src/AasxServerStandardBib/AasxRestServer.cs
+++ b/src/AasxServerStandardBib/AasxRestServer.cs
@@ -1653,7 +1653,7 @@ namespace AasxRestServerLibrary
 
             [RestRoute(
                 HttpMethod = HttpMethod.GET,
-                PathInfo = "^/aas/(id|([^/]+))/submodels/([^/]+)/elements(/([^/]+)){1,99}?/fragments/([a-zA-Z0-9]+)/(.*)$")]
+                PathInfo = "^/aas/(id|([^/]+))/submodels/([^/]+)/elements(/([^/]+)){1,99}?(/fragments/([a-zA-Z0-9]+)/(.*))$")]
             public IHttpContext GetSubmodelElementFragmentContents(IHttpContext context)
             {
                 var m = helper.PathInfoRegexMatch(MethodBase.GetCurrentMethod(), context.Request.PathInfo);
@@ -1662,13 +1662,24 @@ namespace AasxRestServerLibrary
                     var aasid = m.Groups[1].ToString();
                     var smid = m.Groups[3].ToString();
                     var elemids = new List<string>();
-                    var fragmentType = m.Groups[6].ToString();
-                    var fragment = m.Groups[7].ToString().TrimEnd(new[] { '/' });
 
                     for (int i = 0; i < m.Groups[5].Captures.Count; i++)
                         elemids.Add(m.Groups[5].Captures[i].ToString());
 
-                    helper.EvalGetSubmodelElementFragment(context, aasid, smid, elemids.ToArray(), fragmentType, fragment);
+                    // a string describing potentially nested fragments, i.e. "/fragments/<type1>/<fragment1>/fragments/<type2>/<fragment2>/..."
+                    var fragmentString = m.Groups[6].ToString();
+
+                    var nestedFragmentStrings = fragmentString.Split(new[] { "/fragments/" }, StringSplitOptions.RemoveEmptyEntries);
+
+                    List<(string fragmentType, string fragment)> nestedFragments = new List<(string, string)>();
+
+                    foreach(var fragment in nestedFragmentStrings)
+                    {
+                        var parts = fragment.Split(new[] { '/' }, 2);
+                        nestedFragments.Add((parts[0], parts[1].TrimEnd(new[] { '/' })));
+                    }
+
+                    helper.EvalGetSubmodelElementFragment(context, aasid, smid, elemids.ToArray(), nestedFragments);
                 }
                 return context;
             }


### PR DESCRIPTION
This adds support for nested fragments, i.e. repeated sequences of .../fragments/<fragment-type>/<fragment-value>/fragments/<...>/...>/...

A first implementation is provided for Zip files so that the rest API can now be used to query files inside Zip files (inside an AAS).