### PR TITLE
Jtikekar/mm v3 rc02/ape compatibility issue

### DIFF
--- a/src/AasxServerStandardBib/AdminShellPackageEnv.cs
+++ b/src/AasxServerStandardBib/AdminShellPackageEnv.cs
@@ -9,6 +9,8 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using AasCore.Aas3_0_RC02;
 using Extenstions;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 using MimeKit;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -201,14 +203,14 @@ namespace AdminShellNS
             }
 
             // read V3.0?
-            if (nsuri != null && nsuri.Trim() == "http://www.admin-shell.io/aas/3/0")
+            if (nsuri != null && nsuri.Trim() == Xmlization.NS)
             {
                 //XmlSerializer serializer = new XmlSerializer(
                 //    typeof(AasCore.Aas3_0_RC02.Environment), "http://www.admin-shell.io/aas/3/0");
                 //res = serializer.Deserialize(s) as AasCore.Aas3_0_RC02.Environment;
-
                 XmlReader xmlReader = XmlReader.Create(s);
                 //res = Xmlization.Deserialize.EnvironmentFrom(xmlReader, "http://www.admin-shell.io/aas/3/0");
+                xmlReader.MoveToContent();
                 res = Xmlization.Deserialize.EnvironmentFrom(xmlReader);
                 return res;
             }

--- a/src/IO.Swagger.V1RC03/APIModels/Core/CoreTransformer.cs
+++ b/src/IO.Swagger.V1RC03/APIModels/Core/CoreTransformer.cs
@@ -2583,9 +2583,10 @@ namespace IO.Swagger.V1RC03.APIModels.Core
             return result;
         }
 
-        public JsonObject Transform(List<LangString> that, OutputModifierContext context)
+        //public JsonObject Transform(List<LangString> that, OutputModifierContext context)
+        public JsonNode Transform(List<LangString> that, OutputModifierContext context)
         {
-            var result = new JsonObject();
+            //var result = new JsonObject();
 
             var arrayLangStrings = new JsonArray();
             foreach (LangString item in that)
@@ -2594,9 +2595,11 @@ namespace IO.Swagger.V1RC03.APIModels.Core
                     Transform(
                         item, context));
             }
-            result["langStrings"] = arrayLangStrings;
+            //result["langStrings"] = arrayLangStrings;
 
-            return result;
+            //return result;
+
+            return arrayLangStrings;
         }
 
         public JsonObject Transform(IDataSpecificationContent that, OutputModifierContext context)

--- a/src/IO.Swagger.V1RC03/APIModels/Metadata/MetadataTransfomer.cs
+++ b/src/IO.Swagger.V1RC03/APIModels/Metadata/MetadataTransfomer.cs
@@ -2118,9 +2118,9 @@ namespace IO.Swagger.V1RC03.APIModels.Metadata
         }
 
         //public override Nodes.JsonObject Transform(List<LangString> that)
-        public Nodes.JsonObject Transform(List<LangString> that)
+        public Nodes.JsonNode Transform(List<LangString> that)
         {
-            var result = new Nodes.JsonObject();
+            //var result = new Nodes.JsonObject();
 
             var arrayLangStrings = new Nodes.JsonArray();
             foreach (LangString item in that)
@@ -2129,9 +2129,9 @@ namespace IO.Swagger.V1RC03.APIModels.Metadata
                     Transform(
                         item));
             }
-            result["langStrings"] = arrayLangStrings;
+            //result["langStrings"] = arrayLangStrings;
 
-            return result;
+            return arrayLangStrings;
         }
 
 

--- a/src/IO.Swagger.V1RC03/Controllers/AASXFileServerAPI.cs
+++ b/src/IO.Swagger.V1RC03/Controllers/AASXFileServerAPI.cs
@@ -131,12 +131,12 @@ namespace IO.Swagger.V1RC03.Controllers
         [Route("/packages")]
         [ValidateModelState]
         [SwaggerOperation("PostAASXPackage")]
-        public virtual IActionResult PostAASXPackage([FromForm] string aasIds, [FromForm] IFormFile file, [FromForm] string fileName)
+        public virtual IActionResult PostAASXPackage([FromForm] string aasIds, IFormFile file)
         {
             //TODO jtikekar aasIds
             var stream = new MemoryStream();
             file.CopyTo(stream);
-            var packageId = _fileService.PostAASXPackage(stream.ToArray(), fileName);
+            var packageId = _fileService.PostAASXPackage(stream.ToArray(), file.FileName);
             return CreatedAtAction(nameof(PostAASXPackage), packageId);
         }
 

--- a/src/IO.Swagger.V1RC03/IO.Swagger.V1RC03.xml
+++ b/src/IO.Swagger.V1RC03/IO.Swagger.V1RC03.xml
@@ -1177,7 +1177,7 @@
             <response code="200">Requested package list</response>
             <response code="0">Default error handling for unmentioned status codes</response>
         </member>
-        <member name="M:IO.Swagger.V1RC03.Controllers.AASXFileServerApiController.PostAASXPackage(System.String,Microsoft.AspNetCore.Http.IFormFile,System.String)">
+        <member name="M:IO.Swagger.V1RC03.Controllers.AASXFileServerApiController.PostAASXPackage(System.String,Microsoft.AspNetCore.Http.IFormFile)">
             <summary>
             Creates an AASX package at the server
             </summary>

--- a/src/IO.Swagger.V1RC03/Services/AasxFileServerInterfaceService.cs
+++ b/src/IO.Swagger.V1RC03/Services/AasxFileServerInterfaceService.cs
@@ -167,6 +167,10 @@ namespace IO.Swagger.V1RC03.Services
                 {
                     _packages[emptyPackageIndex] = newAasx;
                     _envFileNames[emptyPackageIndex] = newFileName;
+                    foreach (var submodel in newAasx.AasEnv.Submodels) 
+                    { 
+                        submodel.SetAllParents();
+                    }
                     AasxServer.Program.signalNewData(2);
                     return emptyPackageIndex.ToString();
                 }

--- a/src/IO.Swagger.V1RC03/Services/AssetAdministrationShellEnvironmentService.cs
+++ b/src/IO.Swagger.V1RC03/Services/AssetAdministrationShellEnvironmentService.cs
@@ -869,7 +869,7 @@ namespace IO.Swagger.V1RC03.Services
                         list.Value.Remove(submodelElement);
                         list.Value.Insert(smeIndex, body);
                     }
-                    //Added support for submodel here, as no other api found for this functionality
+                    //Added support for submodel here, as no other api smReffound for this functionality
                     else if (smeParent is Submodel submodel)
                     {
                         var smeIndex = submodel.SubmodelElements.IndexOf(submodelElement);
@@ -1079,6 +1079,26 @@ namespace IO.Swagger.V1RC03.Services
                 {
                     body.SetAllParents(DateTime.UtcNow);
                     _packages[packageIndex].AasEnv.Submodels.Add(body);
+                    //Add reference to the aas, if not present
+                    var submodelReference = body.GetReference();
+                    if (submodelReference != null)
+                    {
+                        bool smReffound = false;
+                        //check if submodelRef already exists in aas
+                        foreach (var aasSmRef in aas.Submodels)
+                        {
+                            if (submodelReference.Matches(aasSmRef))
+                            {
+                                smReffound = true;
+                                break;
+                            }
+                        }
+
+                        if (!smReffound)
+                        {
+                            aas.Submodels.Add(submodelReference);
+                        }
+                    }
                     AasxServer.Program.signalNewData(2);
                     return body; // TODO: jtikekar find proper solution
                 }


### PR DESCRIPTION
This PR consists of minor BugFixes as follows:

1. Json de/serialization discrepancy due to different handling of "LangStringSet" in AasCore-SDKs
2. Using "Xmlization.NS" for V3.0 Namespace
3. Calling "submodel.SetAllParent" while uploading a new AASXPackage in the server